### PR TITLE
[BOT] Shafin/bot 1970/chore  webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
         "node": "18.x"
     },
     "scripts": {
-        "start": "rsbuild dev",
-        "build": "rsbuild build",
-        "start:wp": "webpack serve --open --config webpack.config.js",
-        "build:wp": "webpack --config webpack.config.js",
+        "start:rs": "rsbuild dev",
+        "build:rs": "rsbuild build",
+        "start": "webpack serve --open --config webpack.config.js",
+        "build": "webpack --config webpack.config.js",
         "test:lint": "prettier --log-level silent --write . && eslint \"./src/**/*.?(js|jsx|ts|tsx)\"",
         "test:fix": "prettier --log-level silent --write . && eslint --fix \"./src/**/*.?(js|jsx|ts|tsx)\"",
         "test": "jest",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,12 +36,15 @@ module.exports = {
                     },
                     {
                         loader: 'sass-loader',
-                        options: { sourceMap: !IS_RELEASE },
-                    },
-                    {
-                        loader: 'sass-resources-loader',
                         options: {
-                            resources: require(path.resolve(__dirname, 'src/components/shared/styles/index.js')),
+                            sourceMap: !IS_RELEASE,
+                            additionalData: `
+                                                    @import "${path.resolve(__dirname, 'src/components/shared/styles/constants.scss')}";
+                                                    @import "${path.resolve(__dirname, 'src/components/shared/styles/mixins.scss')}";
+                                                    @import "${path.resolve(__dirname, 'src/components/shared/styles/fonts.scss')}";
+                                                    @import "${path.resolve(__dirname, 'src/components/shared/styles/inline-icons.scss')}";
+                                                    @import "${path.resolve(__dirname, 'src/components/shared/styles/devices.scss')}";
+                                                `,
                         },
                     },
                 ],


### PR DESCRIPTION
### Changes

- remove the usage of `sass-resources-loader` to have a proper comparison between Rsbuild from this PR https://github.com/deriv-com/bot/pull/25