### PR TITLE
[BOT] Mayuran/bot-2268/Address chart overlap and other chart  issues and UI issues

### DIFF
--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -11,6 +11,7 @@
     --zindex-modal: 6;
     --zindex-draggable-modal: 7;
     --zindex-snackbar: 8;
+
     &-dashboard {
         background: var(--general-section-1);
     }
@@ -26,13 +27,14 @@
     height: 100%;
     bottom: 0;
     left: 0;
-    background: rgba(0, 0, 0, 0.72);
+    background: rgb(0 0 0 / 72%);
     right: 0;
     opacity: 0;
     z-index: -1;
 }
+
 .modal-root:not(:empty) {
     display: flex;
     opacity: 1;
-    z-index: 10;
+    z-index: 9998;
 }

--- a/src/components/layout/footer/footer.scss
+++ b/src/components/layout/footer/footer.scss
@@ -7,7 +7,7 @@
     flex-direction: row-reverse;
     padding: 0 1rem;
     align-items: center;
-    position: absolute;
+    position: fixed;
     bottom: 0;
     right: 0;
     left: 0;

--- a/src/pages/chart/chart.scss
+++ b/src/pages/chart/chart.scss
@@ -59,7 +59,7 @@
             display: flex;
             flex-wrap: wrap;
             position: absolute;
-            top: 0;
+            top: 10px;
             width: 100%;
         }
 
@@ -102,18 +102,6 @@
         }
     }
 
-    .smartcharts-desktop {
-        .cq-modal-dropdown {
-            .sc-dialog {
-                position: absolute !important;
-                top: -50% !important;
-                left: 50% !important;
-                transform: translate(-50%, -50%) !important;
-                z-index: 9999 !important;
-            }
-        }
-    }
-
     .smartcharts-mobile {
         .cq-context {
             z-index: 99;
@@ -146,16 +134,4 @@
 .cq-modal-dropdown.stxMenuActive {
     left: 0;
     top: 0;
-}
-
-.smartcharts-mobile {
-    .cq-modal__overlay {
-        position: unset !important;
-
-        .sc-dialog {
-            position: absolute !important;
-            top: -85% !important;
-            z-index: 99999 !important;
-        }
-    }
 }

--- a/src/pages/chart/chart.tsx
+++ b/src/pages/chart/chart.tsx
@@ -46,9 +46,9 @@ const Chart = observer(({ show_digits_stats }: { show_digits_stats: boolean }) =
         updateGranularity,
         updateSymbol,
         setChartSubscriptionId,
-        chartSubscriptionId,
+        chart_subscription_id,
     } = chart_store;
-    const chartSubscriptionIdRef = useRef(chartSubscriptionId);
+    const chartSubscriptionIdRef = useRef(chart_subscription_id);
     const { isDesktop, isMobile } = useDevice();
     const { is_drawer_open } = run_panel;
     const { is_chart_modal_visible } = dashboard;
@@ -68,8 +68,8 @@ const Chart = observer(({ show_digits_stats }: { show_digits_stats: boolean }) =
     }, []);
 
     useEffect(() => {
-        chartSubscriptionIdRef.current = chart_store.chartSubscriptionId;
-    }, [chart_store.chartSubscriptionId]);
+        chartSubscriptionIdRef.current = chart_subscription_id;
+    }, [chart_subscription_id]);
 
     useEffect(() => {
         if (!symbol) updateSymbol();

--- a/src/pages/chart/toolbar-widgets.tsx
+++ b/src/pages/chart/toolbar-widgets.tsx
@@ -10,29 +10,22 @@ type TToolbarWidgetsProps = {
 
 const ToolbarWidgets = ({ updateChartType, updateGranularity, position }: TToolbarWidgetsProps) => {
     return (
-        <>
-            <div id='chart_modal_root' />
-            <ToolbarWidget position={position}>
-                <ChartMode
-                    portalNodeId='chart_modal_root'
-                    onChartType={updateChartType}
-                    onGranularity={updateGranularity}
-                />
-                {isDesktop() && (
-                    <>
-                        <StudyLegend portalNodeId='chart_modal_root' searchInputClassName='data-hj-whitelist' />
-                        <Views
-                            portalNodeId='chart_modal_root'
-                            onChartType={updateChartType}
-                            onGranularity={updateGranularity}
-                            searchInputClassName='data-hj-whitelist'
-                        />
-                        <DrawTools portalNodeId='chart_modal_root' />
-                        <Share portalNodeId='chart_modal_root' />
-                    </>
-                )}
-            </ToolbarWidget>
-        </>
+        <ToolbarWidget position={position}>
+            <ChartMode portalNodeId='modal_root' onChartType={updateChartType} onGranularity={updateGranularity} />
+            {isDesktop() && (
+                <>
+                    <StudyLegend portalNodeId='modal_root' searchInputClassName='data-hj-whitelist' />
+                    <Views
+                        portalNodeId='modal_root'
+                        onChartType={updateChartType}
+                        onGranularity={updateGranularity}
+                        searchInputClassName='data-hj-whitelist'
+                    />
+                    <DrawTools portalNodeId='modal_root' />
+                    <Share portalNodeId='modal_root' />
+                </>
+            )}
+        </ToolbarWidget>
     );
 };
 

--- a/src/stores/chart-store.ts
+++ b/src/stores/chart-store.ts
@@ -22,6 +22,8 @@ export default class ChartStore {
             updateChartType: action,
             setChartStatus: action,
             restoreFromStorage: action,
+            chartSubscriptionId: observable,
+            setChartSubscriptionId: action,
         });
 
         this.root_store = root_store;
@@ -39,6 +41,7 @@ export default class ChartStore {
         id: null,
         subscriber: null,
     };
+    chartSubscriptionId = '';
 
     symbol: string | undefined;
     is_chart_loading: boolean | undefined;
@@ -136,5 +139,8 @@ export default class ChartStore {
                 },
                 has_synthetic_index ? [synthetic_index] : []
             );
+    };
+    setChartSubscriptionId = (chartSubscriptionId: string) => {
+        this.chartSubscriptionId = chartSubscriptionId;
     };
 }

--- a/src/stores/chart-store.ts
+++ b/src/stores/chart-store.ts
@@ -22,7 +22,7 @@ export default class ChartStore {
             updateChartType: action,
             setChartStatus: action,
             restoreFromStorage: action,
-            chartSubscriptionId: observable,
+            chart_subscription_id: observable,
             setChartSubscriptionId: action,
         });
 
@@ -41,7 +41,7 @@ export default class ChartStore {
         id: null,
         subscriber: null,
     };
-    chartSubscriptionId = '';
+    chart_subscription_id = '';
 
     symbol: string | undefined;
     is_chart_loading: boolean | undefined;
@@ -141,6 +141,6 @@ export default class ChartStore {
             );
     };
     setChartSubscriptionId = (chartSubscriptionId: string) => {
-        this.chartSubscriptionId = chartSubscriptionId;
+        this.chart_subscription_id = chartSubscriptionId;
     };
 }


### PR DESCRIPTION
We had an issue with re-renders when switching tabs, which caused the chart to stop functioning. During these re-renders, the two functions requestForget={() => {}} and requestForgetStream={() => {}} were being called unnecessarily. To resolve this, I removed those calls and now handle the logic manually in the requestSubscribe function.
When a new symbol call is triggered, I call the forget ws call for the old subscription ID, and updateing i the new subscription ID as well in the store. This way, we manage the subscriptions ourselves.
requestForgetStream(chartSubscriptionIdRef.current);
const history = await chart_api.api.send(req);
setChartSubscriptionId(history?.subscription.id);
2. The subscription ID is stored in chart-store.
Moreover, I couldn't delete the mandatory functions from the chart, namely requestForget={() => {}} and requestForgetStream={() => {}}.
so i kept those as empty.
3. And resolved the problem where clicking on closed markets caused it to keep loading.
4 . fixed ui issues and overlay ( [https://github.com/https://github.com/deriv-com/bot/pull/60] . and i have fixed all the ui isues mentiones in this PR by @maryia-matskevich-deriv )