### PR TITLE
fix: account switcher disabled item showing as active

### DIFF
--- a/src/components/layout/header/account-switcher.tsx
+++ b/src/components/layout/header/account-switcher.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { observer } from 'mobx-react-lite';
 import Popover from '@/components/shared_ui/popover';
 import useModifiedAccountList from '@/hooks/api/account/useAccountList';
@@ -30,13 +31,19 @@ const RenderAccountItems = ({ isVirtual }: Partial<TAccountSwitcherProps>) => {
                 {modifiedAccountList
                     ?.filter(account => (isVirtual ? account.is_virtual : !account.is_virtual))
                     .map(account => (
-                        <UIAccountSwitcher.AccountsItem
+                        <span
+                            className={clsx('account-switcher__item', {
+                                'account-switcher__item--disabled': account.is_disabled,
+                            })}
                             key={account.loginid}
-                            account={account}
-                            onSelectAccount={() => {
-                                switchAccount(account.loginid);
-                            }}
-                        />
+                        >
+                            <UIAccountSwitcher.AccountsItem
+                                account={account}
+                                onSelectAccount={() => {
+                                    if (!account.is_disabled) switchAccount(account.loginid);
+                                }}
+                            />
+                        </span>
                     ))}
             </UIAccountSwitcher.AccountsPanel>
 

--- a/src/components/layout/header/header.scss
+++ b/src/components/layout/header/header.scss
@@ -20,6 +20,12 @@
 }
 
 .account-switcher {
+    &__item {
+        &--disabled {
+            opacity: 0.32;
+        }
+    }
+
     &-footer {
         background: var(--general-main-1);
     }

--- a/src/hooks/api/account/useAccountList.tsx
+++ b/src/hooks/api/account/useAccountList.tsx
@@ -33,7 +33,7 @@ const useModifiedAccountList = () => {
                 isActive: account?.loginid === activeLoginid,
             };
         });
-    }, [accountList, balanceData, activeLoginid]);
+    }, [accountList, balanceData, activeLoginid, client.website_status]);
 
     return {
         /** User's active accounts list. */

--- a/src/hooks/api/account/useAccountList.tsx
+++ b/src/hooks/api/account/useAccountList.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { CurrencyIcon } from '@/components/currency/currency-icon';
 import { getDecimalPlaces } from '@/components/shared';
+import { useStore } from '@/hooks/useStore';
 import { useAccountList, useAuthData } from '@deriv-com/api-hooks';
 import { localize } from '@deriv-com/translations';
 import useBalance from './useBalance';
@@ -10,6 +11,7 @@ const useModifiedAccountList = () => {
     const { data: accountList, ...rest } = useAccountList();
     const { data: balanceData } = useBalance();
     const { activeLoginid } = useAuthData();
+    const { client } = useStore();
 
     const modifiedAccounts = useMemo(() => {
         return accountList?.map(account => {
@@ -18,7 +20,9 @@ const useModifiedAccountList = () => {
                 balance:
                     balanceData?.accounts?.[account?.loginid]?.balance?.toFixed(getDecimalPlaces(account.currency)) ??
                     '0',
-                currencyLabel: account?.is_virtual ? localize('Demo') : account?.currency,
+                currencyLabel: account?.is_virtual
+                    ? localize('Demo')
+                    : (client.website_status?.currencies_config?.[account?.currency]?.name ?? account?.currency),
                 icon: (
                     <CurrencyIcon
                         currency={account?.currency?.toLowerCase()}

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -252,9 +252,9 @@ export default class AppStore {
                             window.Blockly?.derivWorkspace
                                 .getAllBlocks()
                                 .filter(block => block.type === 'trade_definition_market')
-                                .forEach(() => {
+                                .forEach(block => {
                                     runIrreversibleEvents(() => {
-                                        const fake_create_event = new window.Blockly.Events.BlockCreate(this);
+                                        const fake_create_event = new window.Blockly.Events.BlockCreate(block);
                                         window.Blockly.Events.fire(fake_create_event);
                                     });
                                 });


### PR DESCRIPTION
Fixed the blockly block reference on account switching.
Added disabled state for disabled account.