### PR TITLE
Farabi/bot-2371/fix-trade-type-icons-in-run-panel 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@deriv/deriv-api": "^1.0.15",
                 "@deriv/deriv-charts": "^2.5.1",
                 "@deriv/js-interpreter": "^3.0.0",
-                "@deriv/quill-icons": "^2.1.2",
+                "@deriv/quill-icons": "^2.2.0",
                 "@svgr/core": "^8.1.0",
                 "@tanstack/react-query": "^5.29.2",
                 "blockly": "^10.4.3",
@@ -2771,9 +2771,10 @@
             }
         },
         "node_modules/@deriv/quill-icons": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-2.1.2.tgz",
-            "integrity": "sha512-CUiItM0SkN5jRfy1cM0SF5ATg8ClCjGhVDY2f6YXh5n1HBPftCN3KoB/OTVckkFjcoR8morS1WGwHC41sa7BBg==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-2.2.0.tgz",
+            "integrity": "sha512-mR9PRYdO9L0usFtGcbFih7hqgi9Ky3y95QM22VEzjrX+Tktf0L0gkJP3XYwxMQRTxc6x4FBJzYw2UY+dGn4RrQ==",
+            "license": "ISC",
             "peerDependencies": {
                 "react": ">= 16",
                 "react-dom": ">= 16"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "@deriv/deriv-api": "^1.0.15",
         "@deriv/deriv-charts": "^2.5.1",
         "@deriv/js-interpreter": "^3.0.0",
-        "@deriv/quill-icons": "^2.1.2",
+        "@deriv/quill-icons": "^2.2.0",
         "@svgr/core": "^8.1.0",
         "@tanstack/react-query": "^5.29.2",
         "blockly": "^10.4.3",

--- a/src/components/shared_ui/contract-card/contract-card-items/contract-type-cell.tsx
+++ b/src/components/shared_ui/contract-card/contract-card-items/contract-type-cell.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import { isLookBacksContract, isSmartTraderContract, isVanillaContract } from '@/components/shared';
-import { IconTradeTypes } from '@/utils/tmp/dummy';
+import { TradeTypeIcon } from '../../../trade-type/trade-type-icon';
 import { TGetContractTypeDisplay } from '../../types';
 
 export type TContractTypeCellProps = {
@@ -20,31 +20,40 @@ const ContractTypeCell = ({
     is_multipliers,
     is_turbos,
     type = '',
-}: TContractTypeCellProps) => (
-    <div className='dc-contract-type'>
-        <div className='dc-contract-type__type-wrapper'>
-            <IconTradeTypes
-                type={is_high_low && !isVanillaContract(type) ? `${type.toLowerCase()}_barrier` : type.toLowerCase()}
-                className='category-type'
-                size={24}
-            />
-        </div>
-        <div
-            className={classNames('dc-contract-type__type-label', {
-                'dc-contract-type__type-label--smarttrader-contract': isSmartTraderContract(type),
-                'dc-contract-type__type-label--lookbacks-contract': isLookBacksContract(type),
-                'dc-contract-type__type-label--multipliers': is_multipliers,
-            })}
-        >
-            <div>
-                {getContractTypeDisplay(type, { isHighLow: is_high_low, showMainTitle: is_multipliers || is_turbos }) ||
-                    ''}
+}: TContractTypeCellProps) => {
+    let higher_lower_trade_type = '';
+    if (is_high_low) {
+        higher_lower_trade_type = type === 'CALL' ? 'HIGHER' : 'LOWER';
+    }
+
+    return (
+        <div className='dc-contract-type'>
+            <div className='dc-contract-type__type-wrapper'>
+                <TradeTypeIcon
+                    type={is_high_low && !isVanillaContract(type) ? higher_lower_trade_type : type}
+                    className='category-type'
+                    size='md'
+                />
             </div>
-            {displayed_trade_param && (
-                <div className='dc-contract-type__type-label-trade-param'>{displayed_trade_param}</div>
-            )}
+            <div
+                className={classNames('dc-contract-type__type-label', {
+                    'dc-contract-type__type-label--smarttrader-contract': isSmartTraderContract(type),
+                    'dc-contract-type__type-label--lookbacks-contract': isLookBacksContract(type),
+                    'dc-contract-type__type-label--multipliers': is_multipliers,
+                })}
+            >
+                <div>
+                    {getContractTypeDisplay(type, {
+                        isHighLow: is_high_low,
+                        showMainTitle: is_multipliers || is_turbos,
+                    }) || ''}
+                </div>
+                {displayed_trade_param && (
+                    <div className='dc-contract-type__type-label-trade-param'>{displayed_trade_param}</div>
+                )}
+            </div>
         </div>
-    </div>
-);
+    );
+};
 
 export default ContractTypeCell;

--- a/src/components/trade-type/trade-type-icon.tsx
+++ b/src/components/trade-type/trade-type-icon.tsx
@@ -1,0 +1,111 @@
+import { lazy, Suspense } from 'react';
+import { IconSize } from '@deriv/quill-icons';
+
+const TRADE_TYPE_ICONS = {
+    ACCU: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesAccumulatorStayInIcon }))
+    ),
+    DIGITDIFF: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesDigitsDiffersIcon }))
+    ),
+    DIGITEVEN: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesDigitsEvenIcon }))
+    ),
+    DIGITMATCH: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesDigitsMatchesIcon }))
+    ),
+    DIGITODD: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesDigitsOddIcon }))
+    ),
+    DIGITOVER: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesDigitsOverIcon }))
+    ),
+    DIGITUNDER: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesDigitsUnderIcon }))
+    ),
+    TICKHIGH: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesHighsAndLowsHighIcon }))
+    ),
+    TICKLOW: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesHighsAndLowsLowIcon }))
+    ),
+    NOTOUCH: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesHighsAndLowsNoTouchIcon }))
+    ),
+    ONETOUCH: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesHighsAndLowsTouchIcon }))
+    ),
+    EXPIRYRANGE: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesInsAndOutsEndsInIcon }))
+    ),
+    EXPIRYMISS: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesInsAndOutsEndsOutIcon }))
+    ),
+    UPORDOWN: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesInsAndOutsGoesOutIcon }))
+    ),
+    RANGE: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesInsAndOutsStaysInIcon }))
+    ),
+    MULTDOWN: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesMultipliersDownIcon }))
+    ),
+    MULTUP: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesMultipliersUpIcon }))
+    ),
+    CALLSPREAD: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesSpreadsCallIcon }))
+    ),
+    PUTSPREAD: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesSpreadsPutIcon }))
+    ),
+    ASIAND: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesUpsAndDownsAsianDownIcon }))
+    ),
+    ASIANU: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesUpsAndDownsAsianUpIcon }))
+    ),
+    PUT: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesUpsAndDownsFallIcon }))
+    ),
+    PUTE: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesUpsAndDownsFallIcon }))
+    ),
+    RUNLOW: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesUpsAndDownsOnlyDownsIcon }))
+    ),
+    RUNHIGH: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesUpsAndDownsOnlyUpsIcon }))
+    ),
+    RESETPUT: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesUpsAndDownsResetDownIcon }))
+    ),
+    RESETCALL: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesUpsAndDownsResetUpIcon }))
+    ),
+    CALL: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesUpsAndDownsRiseIcon }))
+    ),
+    CALLE: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesUpsAndDownsRiseIcon }))
+    ),
+    HIGHER: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesHighsAndLowsHigherIcon }))
+    ),
+    LOWER: lazy(() =>
+        import('@deriv/quill-icons/TradeTypes').then(module => ({ default: module.TradeTypesHighsAndLowsLowerIcon }))
+    ),
+    unknown: lazy(() =>
+        import('@deriv/quill-icons/Illustrative').then(module => ({ default: module.IllustrativeMarketsIcon }))
+    ),
+};
+
+export const TradeTypeIcon = ({ type, size }: { type: string; size?: IconSize }) => {
+    const Icon = TRADE_TYPE_ICONS[type?.toUpperCase() as keyof typeof TRADE_TYPE_ICONS] || TRADE_TYPE_ICONS.unknown;
+
+    return (
+        <Suspense fallback={null}>
+            <Icon iconSize={size ?? 'xs'} />
+        </Suspense>
+    );
+};

--- a/src/components/transaction-details/desktop-transaction-table.tsx
+++ b/src/components/transaction-details/desktop-transaction-table.tsx
@@ -4,10 +4,10 @@ import ContentLoader from 'react-content-loader';
 import { transaction_elements } from '@/constants/transactions';
 import { getContractTypeName } from '@/external/bot-skeleton';
 import { isDbotRTL } from '@/external/bot-skeleton/utils/workspace';
-import { IconTradeTypes } from '@/utils/tmp/dummy';
 import { MarketIcon } from '../market/market-icon';
 import { convertDateFormat } from '../shared';
 import Popover from '../shared_ui/popover';
+import { TradeTypeIcon } from '../trade-type/trade-type-icon';
 import { TColumn, TDesktopTransactionTable, TTableCell } from './transaction-details.types';
 
 const PARENT_CLASS = 'transaction-details-modal-desktop';
@@ -104,7 +104,7 @@ export default function DesktopTransactionTable({
                                     label={
                                         <IconWrapper
                                             message={getContractTypeName(data)}
-                                            icon={<IconTradeTypes type={data?.contract_type} size={24} />}
+                                            icon={<TradeTypeIcon type={data?.contract_type} size='sm' />}
                                         />
                                     }
                                 />

--- a/src/components/transaction-details/mobile-transaction-card.tsx
+++ b/src/components/transaction-details/mobile-transaction-card.tsx
@@ -3,11 +3,11 @@ import classNames from 'classnames';
 import ContentLoader from 'react-content-loader';
 import { getContractTypeName } from '@/external/bot-skeleton';
 import { isDbotRTL } from '@/external/bot-skeleton/utils/workspace';
-import { IconTradeTypes } from '@/utils/tmp/dummy';
 import { localize } from '@deriv-com/translations';
 import { MarketIcon } from '../market/market-icon';
 import { convertDateFormat } from '../shared';
 import Popover from '../shared_ui/popover';
+import { TradeTypeIcon } from '../trade-type/trade-type-icon';
 import { TTransaction } from './transaction-details.types';
 
 const PARENT_CLASS = 'transaction-details-modal-mobile';
@@ -83,7 +83,7 @@ export default function MobileTransactionCards({ transaction }: { transaction: T
                             />
                             <IconContainer
                                 message={getContractTypeName(transaction)}
-                                icon={<IconTradeTypes type={transaction?.contract_type} size={24} />}
+                                icon={<TradeTypeIcon type={transaction?.contract_type} size='md' />}
                             />
                         </div>
                     }

--- a/src/components/transactions/transaction.tsx
+++ b/src/components/transactions/transaction.tsx
@@ -6,12 +6,12 @@ import { TContractInfo } from '@/components/summary/summary-card.types';
 import { popover_zindex } from '@/constants/z-indexes';
 import { getContractTypeName } from '@/external/bot-skeleton';
 import { isDbotRTL } from '@/external/bot-skeleton/utils/workspace';
-import { IconTradeTypes } from '@/utils/tmp/dummy';
 import { LegacyRadioOffIcon, LegacyRadioOnIcon } from '@deriv/quill-icons';
 import { Localize, localize } from '@deriv-com/translations';
 import { MarketIcon } from '../market/market-icon';
 import { convertDateFormat } from '../shared';
 import Popover from '../shared_ui/popover';
+import { TradeTypeIcon } from '../trade-type/trade-type-icon';
 
 type TTransactionIconWithText = {
     icon: React.ReactElement;
@@ -185,7 +185,7 @@ const Transaction = ({ contract, active_transaction_id, onClickTransaction }: TT
                     <div className='transactions__loader-container'>
                         {contract ? (
                             <TransactionIconWithText
-                                icon={<IconTradeTypes type={contract.contract_type || ''} size={16} />}
+                                icon={<TradeTypeIcon type={contract.contract_type || ''} size='sm' />}
                                 title={getContractTypeName(contract)}
                             />
                         ) : (

--- a/src/components/transactions/transactions.scss
+++ b/src/components/transactions/transactions.scss
@@ -187,6 +187,7 @@
         &-container {
             @include flex-center;
 
+            align-items: flex-start;
             width: 2.4rem;
             height: 2.4rem;
             margin-right: 0.4rem;


### PR DESCRIPTION
## Changes:

- Added all the trade type icons from quill icons to summary and transaction tabs.