### PR TITLE
chore: fix reload on device wakeup if bot was running

### DIFF
--- a/src/components/layout/header/account-switcher.tsx
+++ b/src/components/layout/header/account-switcher.tsx
@@ -87,7 +87,6 @@ const RenderAccountItems = ({ isVirtual, modifiedAccountList, switchAccount }: T
                         className='deriv-account-switcher__logout'
                         onClick={() => {
                             client.logout();
-                            api_base?.api?.logout();
                         }}
                     >
                         <Text color='prominent' size='xs' align='left' className='deriv-account-switcher__logout-text'>
@@ -107,17 +106,7 @@ const RenderAccountItems = ({ isVirtual, modifiedAccountList, switchAccount }: T
 
 const AccountSwitcher = observer(({ activeAccount }: TAccountSwitcher) => {
     const { accountList } = useApiBase();
-    const { ui, run_panel, client } = useStore() ?? {
-        ui: {
-            account_switcher_disabled_message: '',
-        },
-        run_panel: {
-            is_stop_button_visible: false,
-        },
-        client: {
-            all_accounts_balance: {},
-        },
-    };
+    const { ui, run_panel, client } = useStore();
     const { account_switcher_disabled_message } = ui;
     const { is_stop_button_visible } = run_panel;
 

--- a/src/external/bot-skeleton/services/api/api-base.ts
+++ b/src/external/bot-skeleton/services/api/api-base.ts
@@ -107,7 +107,6 @@ class APIBase {
 
         if (this.time_interval) clearInterval(this.time_interval);
         this.time_interval = null;
-        this.getTime();
 
         if (V2GetActiveToken()) {
             setIsAuthorizing(true);
@@ -257,14 +256,6 @@ class APIBase {
         global_timeouts.forEach((_: unknown, i: number) => {
             clearTimeout(i);
         });
-    }
-
-    getTime() {
-        if (!this.time_interval) {
-            this.time_interval = setInterval(() => {
-                this.api?.send({ time: 1 });
-            }, 30000);
-        }
     }
 }
 

--- a/src/pages/main/main.tsx
+++ b/src/pages/main/main.tsx
@@ -8,10 +8,10 @@ import MobileWrapper from '@/components/shared_ui/mobile-wrapper';
 import Tabs from '@/components/shared_ui/tabs/tabs';
 import TradingViewModal from '@/components/trading-view-chart/trading-view-modal';
 import { DBOT_TABS, TAB_IDS } from '@/constants/bot-contents';
-import { updateWorkspaceName } from '@/external/bot-skeleton';
-import dbot from '@/external/bot-skeleton/scratch/dbot';
-import { api_base } from '@/external/bot-skeleton/services/api/api-base';
+import { api_base, updateWorkspaceName } from '@/external/bot-skeleton';
+import { CONNECTION_STATUS } from '@/external/bot-skeleton/services/api/observables/connection-status-stream';
 import { isDbotRTL } from '@/external/bot-skeleton/utils/workspace';
+import { useApiBase } from '@/hooks/useApiBase';
 import { useStore } from '@/hooks/useStore';
 import {
     LabelPairedChartLineCaptionRegularIcon,
@@ -30,6 +30,7 @@ const Chart = lazy(() => import('../chart'));
 const Tutorial = lazy(() => import('../tutorials'));
 
 const AppWrapper = observer(() => {
+    const { connectionStatus } = useApiBase();
     const { dashboard, load_modal, run_panel, quick_strategy, summary_card } = useStore();
     const {
         active_tab,
@@ -42,8 +43,15 @@ const AppWrapper = observer(() => {
         setTourDialogVisibility,
     } = dashboard;
     const { onEntered, dashboard_strategies } = load_modal;
-    const { is_dialog_open, is_drawer_open, dialog_options, onCancelButtonClick, onCloseDialog, onOkButtonClick } =
-        run_panel;
+    const {
+        is_dialog_open,
+        is_drawer_open,
+        dialog_options,
+        onCancelButtonClick,
+        onCloseDialog,
+        onOkButtonClick,
+        stopBot,
+    } = run_panel;
     const { is_open } = quick_strategy;
     const { cancel_button_text, ok_button_text, title, message } = dialog_options as { [key: string]: string };
     const { clear } = summary_card;
@@ -62,22 +70,17 @@ const AppWrapper = observer(() => {
     };
     const active_hash_tab = GetHashedValue(active_tab);
 
-    const checkAndHandleConnection = () => {
-        const api_status = api_base.getConnectionStatus();
-        const web_socket_status = ['Connecting', 'Closing', 'Closed'];
-        //added this check because after sleep mode all the store values refresh and is_running is false.
-        const is_bot_running = document.getElementById('db-animation__stop-button') !== null;
-        if (is_bot_running && web_socket_status.includes(api_status)) {
-            dbot.terminateBot();
-            clear();
-            setWebSocketState(false);
-        }
-    };
-
     React.useEffect(() => {
-        window.addEventListener('focus', checkAndHandleConnection);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+        if (connectionStatus !== CONNECTION_STATUS.OPENED) {
+            const is_bot_running = document.getElementById('db-animation__stop-button') !== null;
+            if (is_bot_running) {
+                clear();
+                stopBot();
+                api_base.setIsRunning(false);
+                setWebSocketState(false);
+            }
+        }
+    }, [clear, connectionStatus, setWebSocketState, stopBot]);
 
     React.useEffect(() => {
         if (is_open) {


### PR DESCRIPTION
This pull request includes various improvements and bug fixes across multiple files. The key changes involve fixing the **functionality to show a reload modal if the WS connection got dropped while the bot is running**, renaming a function for clarity, adding error handling for authorization, and cleaning up unused code. Additionally, several refactors were made to improve the codebase.

### Improvements to error handling and code clarity:

* [`src/app/CoreStoreProvider.tsx`](diffhunk://#diff-5ec7969cf78888b570b3224805b4252b136ff69101053e09e361de4be5cdded8L84-R101): Renamed `handleMessage` to `handleMessages` and added error handling for `AuthorizationRequired` errors. [[1]](diffhunk://#diff-5ec7969cf78888b570b3224805b4252b136ff69101053e09e361de4be5cdded8L84-R101) [[2]](diffhunk://#diff-5ec7969cf78888b570b3224805b4252b136ff69101053e09e361de4be5cdded8L115-R129)

### Code cleanup and refactoring:

* [`src/components/layout/header/account-switcher.tsx`](diffhunk://#diff-bf3f2df057110808659b78456c70e733dec577bee954e3fc8391016c313164d1L90): Removed redundant API logout call and unnecessary default values in the `useStore` hook. [[1]](diffhunk://#diff-bf3f2df057110808659b78456c70e733dec577bee954e3fc8391016c313164d1L90) [[2]](diffhunk://#diff-bf3f2df057110808659b78456c70e733dec577bee954e3fc8391016c313164d1L110-R109)
* [`src/external/bot-skeleton/services/api/api-base.ts`](diffhunk://#diff-3b0931891357dd6358fa53dcd1ab528d4de6ec5e344c41956adbe694df9e4c89L110): Removed the `getTime` method and its associated interval setup as it was no longer needed. [[1]](diffhunk://#diff-3b0931891357dd6358fa53dcd1ab528d4de6ec5e344c41956adbe694df9e4c89L110) [[2]](diffhunk://#diff-3b0931891357dd6358fa53dcd1ab528d4de6ec5e344c41956adbe694df9e4c89L261-L268)
* [`src/pages/main/main.tsx`](diffhunk://#diff-e315c9587afa8674eab883837b77bd5ad552be5a25c2b29ea062b071ba4aff36L11-R14): Consolidated imports and refactored connection status handling to use the `useApiBase` hook and `CONNECTION_STATUS` constants. [[1]](diffhunk://#diff-e315c9587afa8674eab883837b77bd5ad552be5a25c2b29ea062b071ba4aff36L11-R14) [[2]](diffhunk://#diff-e315c9587afa8674eab883837b77bd5ad552be5a25c2b29ea062b071ba4aff36R33) [[3]](diffhunk://#diff-e315c9587afa8674eab883837b77bd5ad552be5a25c2b29ea062b071ba4aff36L45-R54) [[4]](diffhunk://#diff-e315c9587afa8674eab883837b77bd5ad552be5a25c2b29ea062b071ba4aff36L65-R83)