### PR TITLE
maryia/fix: Run panel animation result does not match contact result on win/loss

### DIFF
--- a/src/stores/summary-card-store.ts
+++ b/src/stores/summary-card-store.ts
@@ -157,11 +157,11 @@ export default class SummaryCardStore {
     onBotContractEvent(contract: TContractInfo) {
         const { profit } = contract;
         const indicative = getIndicativePrice(contract as ProposalOpenContract);
+        this.profit = profit;
 
         if (this.contract_id !== contract.id) {
             this.clear(false);
             this.contract_id = contract.id;
-            this.profit = profit;
             this.indicative = indicative;
         }
 


### PR DESCRIPTION
fix: Run panel animation result does not match contact result on win/loss

!we need the value of each transaction of the profit field relative to one contract, not just the first one