### PR TITLE
chore: update auth client version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@datadog/browser-rum": "^5.31.1",
                 "@deriv-com/analytics": "^1.5.3",
-                "@deriv-com/auth-client": "^1.2.12",
+                "@deriv-com/auth-client": "^1.2.13",
                 "@deriv-com/quill-ui": "1.18.1",
                 "@deriv-com/translations": "^1.3.9",
                 "@deriv-com/ui": "^1.37.1",
@@ -2594,11 +2594,11 @@
             }
         },
         "node_modules/@deriv-com/auth-client": {
-            "version": "1.2.12",
-            "resolved": "https://registry.npmjs.org/@deriv-com/auth-client/-/auth-client-1.2.12.tgz",
-            "integrity": "sha512-IhZ/di6zQeOkdE4J7PpKBtRu3shIaULU/vWcywheBmya0R/2J5Sy6YHbvRhC8RY+UPOqaz+19g81om8givmPnw==",
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/@deriv-com/auth-client/-/auth-client-1.2.13.tgz",
+            "integrity": "sha512-fHgG0AcPILhr/dWlb8Z5sWFI1D92uzd/6c4hSNwvTU369vLMY5IKoNHu8ERDR9reg9AiBMqVvNpk8Xc+kfwR0g==",
             "dependencies": {
-                "@deriv-com/utils": "^0.0.37",
+                "@deriv-com/utils": "^0.0.42",
                 "@testing-library/react": "^16.0.1",
                 "js-cookie": "3.0.5",
                 "oidc-client-ts": "^3.1.0"
@@ -2702,9 +2702,9 @@
             }
         },
         "node_modules/@deriv-com/utils": {
-            "version": "0.0.37",
-            "resolved": "https://registry.npmjs.org/@deriv-com/utils/-/utils-0.0.37.tgz",
-            "integrity": "sha512-+ngUvT+OqwblBoqkHcsbLtljjwOGIjjMpo5xLS5fwyhtNvBe8Rcq+140QV1j0xq9vlm2kmcowEKIVBq33imFmg=="
+            "version": "0.0.42",
+            "resolved": "https://registry.npmjs.org/@deriv-com/utils/-/utils-0.0.42.tgz",
+            "integrity": "sha512-4JhTpg0sQWCq94RSMGpuT/09bYSV8yO3WdunM2R84qxWNitRH/i4k/xfdleRVzX+xLSmMmJWlkbD6NAlP8U5eg=="
         },
         "node_modules/@deriv/api-types": {
             "version": "1.0.2513",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dependencies": {
         "@datadog/browser-rum": "^5.31.1",
         "@deriv-com/analytics": "^1.5.3",
-        "@deriv-com/auth-client": "^1.2.12",
+        "@deriv-com/auth-client": "^1.2.13",
         "@deriv-com/quill-ui": "1.18.1",
         "@deriv-com/translations": "^1.3.9",
         "@deriv-com/ui": "^1.37.1",


### PR DESCRIPTION
This pull request includes a minor update to the `package.json` file. The change updates the version of the `@deriv-com/auth-client` dependency.

Dependency update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L25-R25): Updated `@deriv-com/auth-client` from version `^1.2.12` to `^1.2.13`.