### PR TITLE
fix: draggable component stuck issue

### DIFF
--- a/src/components/draggable/draggable.tsx
+++ b/src/components/draggable/draggable.tsx
@@ -176,7 +176,11 @@ const Draggable: React.FC<TDraggableProps> = ({
             setIsDragging(false);
             isResizing.current = false;
             if (draggableContentBody?.style) {
-                Object.assign(draggableContentBody.style, previousStyle);
+                try {
+                    Object.assign(draggableContentBody.style, previousStyle);
+                } catch {
+                    draggableContentBody.style.pointerEvents = 'unset';
+                }
             }
             if (boundaryRef) {
                 window.removeEventListener('mousemove', handleMouseMove);


### PR DESCRIPTION
This pull request includes a change to the `Draggable` component in the `src/components/draggable/draggable.tsx` file. The change improves the handling of the draggable content's style when dragging ends.

* [`src/components/draggable/draggable.tsx`](diffhunk://#diff-e4dd126ff7597c535e22f5bdeacd431c5629133012bcfc552d38e3309f02b516R179-R183): Added a `try-catch` block around the `Object.assign` call to handle potential errors and ensure `pointerEvents` is reset to 'unset' if an error occurs.