### PR TITLE
maryia/BOT-2605/fix: The button "Import strategy" does not work on the "Moving strategies to Deriv Bot" announcement modal

### DIFF
--- a/src/pages/dashboard/announcements/announcements.tsx
+++ b/src/pages/dashboard/announcements/announcements.tsx
@@ -137,7 +137,7 @@ const Announcements = observer(({ is_mobile, is_tablet, handleTabChange }: TAnno
         if (selected_announcement?.should_toggle_qs_modal) {
             setFormVisibility(true);
         }
-        if (selected_announcement?.should_toggle_modal) {
+        if (selected_announcement?.should_toggle_load_modal) {
             toggleLoadModal();
         }
         selected_announcement?.onConfirm?.();

--- a/src/pages/tutorials/dbot-tours/bot-builder-tour/bot-builder-tour-desktop.tsx
+++ b/src/pages/tutorials/dbot-tours/bot-builder-tour/bot-builder-tour-desktop.tsx
@@ -10,8 +10,9 @@ import { useTourHandler } from '../useTourHandler';
 
 const BotBuilderTourDesktop = observer(() => {
     const { is_close_tour, is_finished, handleJoyrideCallback, setIsCloseTour } = useTourHandler();
-    const { dashboard } = useStore();
+    const { dashboard, load_modal } = useStore();
     const { active_tab, active_tour, setActiveTour, setTourDialogVisibility } = dashboard;
+    const { is_load_modal_open } = load_modal;
     const token = getSetting('bot_builder_token');
     if (!token && active_tab === 1) setTourDialogVisibility(true);
 
@@ -27,7 +28,7 @@ const BotBuilderTourDesktop = observer(() => {
 
     return (
         <>
-            {!is_finished ? <TourStartDialog /> : <TourEndDialog />}
+            {is_finished ? <TourEndDialog /> : !is_load_modal_open && <TourStartDialog />}
             {active_tour && (
                 <ReactJoyrideWrapper
                     handleCallback={handleJoyrideCallback}

--- a/src/pages/tutorials/dbot-tours/bot-builder-tour/bot-builder-tour-desktop.tsx
+++ b/src/pages/tutorials/dbot-tours/bot-builder-tour/bot-builder-tour-desktop.tsx
@@ -28,7 +28,7 @@ const BotBuilderTourDesktop = observer(() => {
 
     return (
         <>
-            {is_finished ? <TourEndDialog /> : !is_load_modal_open && <TourStartDialog />}
+            {is_finished ? <TourEndDialog /> : (!is_load_modal_open ? <TourStartDialog />: null)}
             {active_tour && (
                 <ReactJoyrideWrapper
                     handleCallback={handleJoyrideCallback}


### PR DESCRIPTION
1) fix: The button "Import strategy" does not work on the "Moving strategies to Deriv Bot" announcement modal
2) fix: Appearance of the tour modal window after we open the download modal window and switch to the bot builder page on the background

https://github.com/user-attachments/assets/97174cd8-6456-4f21-84cd-be062dda959c

