### PR TITLE
fix: converted const to a arrow function

### DIFF
--- a/src/external/bot-skeleton/scratch/blocks/Binary/Before Purchase/purchase.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Before Purchase/purchase.js
@@ -11,7 +11,7 @@ window.Blockly.Blocks.purchase = {
     },
     definition() {
         return {
-            message0: localize('Purchase {{ contract_type }}', { contract_type: '%1' }),
+            message0: localize('Purchase test {{ contract_type }}', { contract_type: '%1' }),
             args0: [
                 {
                     type: 'field_dropdown',

--- a/src/external/bot-skeleton/scratch/blocks/Binary/Before Purchase/purchase.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Before Purchase/purchase.js
@@ -11,7 +11,7 @@ window.Blockly.Blocks.purchase = {
     },
     definition() {
         return {
-            message0: localize('Purchase test {{ contract_type }}', { contract_type: '%1' }),
+            message0: localize('Purchase {{ contract_type }}', { contract_type: '%1' }),
             args0: [
                 {
                     type: 'field_dropdown',

--- a/src/external/bot-skeleton/scratch/utils/index.js
+++ b/src/external/bot-skeleton/scratch/utils/index.js
@@ -623,9 +623,13 @@ const downloadBlock = () => {
     const xml_text = window.Blockly.Xml.domToPrettyText(xml_block);
     saveAs({ data: xml_text, type: 'text/xml;charset=utf-8', filename: 'block.xml' });
 };
+const getLocalizedText = text => {
+    if (!text) return text;
+    return localize(text) || text;
+};
 
 const download_option = () => ({
-    text: localize('Download Block') || 'Download Block',
+    text: getLocalizedText('Download Block') || 'Download Block',
     enabled: true,
     callback: downloadBlock,
 });
@@ -642,11 +646,6 @@ export const excludeOptionFromContextMenu = (menu, exclude_items) => {
 };
 
 const common_included_items = [download_option()];
-
-const getLocalizedText = text => {
-    if (!text) return text;
-    return localize(text) || text;
-};
 
 const all_context_menu_options = () =>
     [

--- a/src/external/bot-skeleton/scratch/utils/index.js
+++ b/src/external/bot-skeleton/scratch/utils/index.js
@@ -624,11 +624,11 @@ const downloadBlock = () => {
     saveAs({ data: xml_text, type: 'text/xml;charset=utf-8', filename: 'block.xml' });
 };
 
-const download_option = {
-    text: localize('Download Block'),
+const download_option = () => ({
+    text: localize('Download Block') || 'Download Block',
     enabled: true,
     callback: downloadBlock,
-};
+});
 
 export const excludeOptionFromContextMenu = (menu, exclude_items) => {
     for (let i = 0; i <= menu.length - 1; i++) {
@@ -641,7 +641,7 @@ export const excludeOptionFromContextMenu = (menu, exclude_items) => {
     }
 };
 
-const common_included_items = [download_option];
+const common_included_items = [download_option()];
 
 const all_context_menu_options = () => [
     localize('Duplicate'),
@@ -654,10 +654,13 @@ const all_context_menu_options = () => [
     localize('Download Block'),
 ];
 
-const deleteBlocksLocaleText = localize('Delete Block');
-const deleteAllBlocksLocaleText = localize('Delete All Blocks');
+const deleteBlocksLocaleText = () => localize('Delete Block');
+const deleteAllBlocksLocaleText = () => localize('Delete All Blocks');
 
 export const modifyContextMenu = (menu, add_new_items = []) => {
+    const all_context_menu_options_ = all_context_menu_options();
+    const delete_block_lacale_text_ = deleteBlocksLocaleText();
+    const delete_all_blocks_locale_text_ = deleteAllBlocksLocaleText();
     const include_items = [...common_included_items, ...add_new_items];
     include_items.forEach(item => {
         menu.push({
@@ -671,13 +674,13 @@ export const modifyContextMenu = (menu, add_new_items = []) => {
         const menu_text = menu[i]?.text?.toLowerCase();
         if (menu_text?.includes('delete')) {
             if (menu_text.includes('block') && !menu_text.includes('blocks')) {
-                menu[i].text = deleteBlocksLocaleText;
+                menu[i].text = delete_block_lacale_text_;
             } else {
-                menu[i].text = deleteAllBlocksLocaleText;
+                menu[i].text = delete_all_blocks_locale_text_;
             }
         } else {
             const localized_text = localize(menu[i].text);
-            if (all_context_menu_options().includes(localized_text)) {
+            if (all_context_menu_options_.includes(localized_text)) {
                 menu[i].text = localized_text;
             }
         }

--- a/src/external/bot-skeleton/scratch/utils/index.js
+++ b/src/external/bot-skeleton/scratch/utils/index.js
@@ -643,16 +643,22 @@ export const excludeOptionFromContextMenu = (menu, exclude_items) => {
 
 const common_included_items = [download_option()];
 
-const all_context_menu_options = () => [
-    localize('Duplicate'),
-    localize('Add Comment'),
-    localize('Remove Comment'),
-    localize('Collapse Block'),
-    localize('Expand Block'),
-    localize('Disable Block'),
-    localize('Enable Block'),
-    localize('Download Block'),
-];
+const getLocalizedText = text => {
+    if (!text) return text;
+    return localize(text) || text;
+};
+
+const all_context_menu_options = () =>
+    [
+        'Duplicate',
+        'Add Comment',
+        'Remove Comment',
+        'Collapse Block',
+        'Expand Block',
+        'Disable Block',
+        'Enable Block',
+        'Download Block',
+    ].map(getLocalizedText);
 
 const deleteBlocksLocaleText = () => localize('Delete Block');
 const deleteAllBlocksLocaleText = () => localize('Delete All Blocks');

--- a/src/external/bot-skeleton/scratch/utils/index.js
+++ b/src/external/bot-skeleton/scratch/utils/index.js
@@ -643,7 +643,7 @@ export const excludeOptionFromContextMenu = (menu, exclude_items) => {
 
 const common_included_items = [download_option];
 
-const all_context_menu_options = [
+const all_context_menu_options = () => [
     localize('Duplicate'),
     localize('Add Comment'),
     localize('Remove Comment'),
@@ -677,7 +677,7 @@ export const modifyContextMenu = (menu, add_new_items = []) => {
             }
         } else {
             const localized_text = localize(menu[i].text);
-            if (all_context_menu_options.includes(localized_text)) {
+            if (all_context_menu_options().includes(localized_text)) {
                 menu[i].text = localized_text;
             }
         }

--- a/src/external/bot-skeleton/utils/error-config.js
+++ b/src/external/bot-skeleton/utils/error-config.js
@@ -1,41 +1,21 @@
-import { Localize } from '@deriv-com/translations';
+const generateErrorMessage = async (block_type, missing_space) => {
+    const { localize } = await import('@deriv-com/translations');
+    if (!missing_space) missing_space = localize('workspace');
 
-const generateErrorMessage = (block_type, missing_space = 'workspace') => {
     return {
-        missing: (
-            <Localize
-                i18n_default_text={`The {{block_type}} block is missing.`}
-                values={{
-                    block_type,
-                }}
-            />
-        ),
-        misplaced: (
-            <Localize
-                i18n_default_text={`The {{block_type}} block is misplaced from {{missing_space}}.`}
-                values={{
-                    block_type,
-                    missing_space,
-                }}
-            />
-        ),
-
-        disabled: (
-            <Localize
-                i18n_default_text={`The {{block_type}} block is mandatory and cannot be deleted/disabled.`}
-                values={{
-                    block_type,
-                }}
-            />
-        ),
-        default: (
-            <Localize
-                i18n_default_text={`The {{block_type}} block is mandatory and cannot be deleted/disabled.`}
-                values={{
-                    block_type,
-                }}
-            />
-        ),
+        missing: localize('The {{block_type}} block is mandatory and cannot be deleted/disabled.', {
+            block_type,
+        }),
+        misplaced: localize('The {{block_type}} block is misplaced from {{missing_space}}.', {
+            block_type,
+            missing_space,
+        }),
+        disabled: localize('The {{block_type}} block is mandatory and cannot be deleted/disabled.', {
+            block_type,
+        }),
+        default: localize('The {{block_type}} block is mandatory and cannot be deleted/disabled.', {
+            block_type,
+        }),
     };
 };
 

--- a/src/external/bot-skeleton/utils/error-handling.js
+++ b/src/external/bot-skeleton/utils/error-handling.js
@@ -20,9 +20,9 @@ export const initErrorHandlingListener = (type = 'keydown') => {
 export const handleError = (errorCode, observer) => {
     switch (errorCode) {
         case 'BLOCK_DELETION':
-            if (error_message_map[window.Blockly.getSelected().type]) {
-                observer.emit('ui.log.error', error_message_map[window.Blockly.getSelected().type]?.default);
-            }
+            error_message_map[window.Blockly.getSelected().type].then(data => {
+                observer.emit('ui.log.error', data?.default?.());
+            });
             break;
         default:
             break;


### PR DESCRIPTION
This pull request includes changes to the `src/external/bot-skeleton/scratch/utils/index.js` file to improve the handling of context menu options by converting a constant array to a function that returns an array. This change ensures that the context menu options are always evaluated at runtime, which can help with dynamic updates and localization.