### PR TITLE
maryia/BOT-2616/fix: Minor CSS bugs on the announcements and quick strategy modal windows

### DIFF
--- a/src/pages/bot-builder/quick-strategy/quick-strategy.scss
+++ b/src/pages/bot-builder/quick-strategy/quick-strategy.scss
@@ -429,7 +429,7 @@
 
             &__field[name='symbol'] {
                 caret-color: auto;
-                margin-inline-start: 4rem;
+                margin-inline-start: 2.4rem;
             }
 
             &__trailing-icon {

--- a/src/pages/bot-builder/quick-strategy/quick-strategy.scss
+++ b/src/pages/bot-builder/quick-strategy/quick-strategy.scss
@@ -429,6 +429,7 @@
 
             &__field[name='symbol'] {
                 caret-color: auto;
+                margin-inline-start: 4rem;
             }
 
             &__trailing-icon {

--- a/src/pages/dashboard/announcements/announcements.scss
+++ b/src/pages/dashboard/announcements/announcements.scss
@@ -66,6 +66,7 @@
 .notifications {
     min-height: 53.6rem !important;
     background-color: var(--general-main-2);
+    border-radius: 0;
 
     @include mobile-or-tablet-screen {
         height: 100svh;


### PR DESCRIPTION
fix: Minor CSS bugs on the announcements and quick strategy modal windows

1)
<img width="744" alt="Screenshot 2024-12-10 at 18 52 03" src="https://github.com/user-attachments/assets/81e84d3f-21e7-40e7-824f-045beaf008dc">
<img width="744" alt="Screenshot 2024-12-10 at 18 52 20" src="https://github.com/user-attachments/assets/eabce757-84b8-46a1-be9e-bd0cd54edb3f">

2)
<img width="552" alt="Screenshot 2024-12-10 at 18 32 05" src="https://github.com/user-attachments/assets/2352a72b-e028-453e-b312-a9fbfeec3f39">
