### PR TITLE
chore: test workflow

### DIFF
--- a/src/utils/datadog.ts
+++ b/src/utils/datadog.ts
@@ -25,6 +25,7 @@ const getConfigValues = (is_production: boolean) => {
 
 const initDatadog = (is_datadog_enabled: boolean) => {
     if (!is_datadog_enabled) return;
+    console.log('current environment: ', process.env.NODE_ENV);
     if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'staging') {
         const is_production = process.env.NODE_ENV === 'production';
         const {


### PR DESCRIPTION
This pull request includes a small change to the `src/utils/datadog.ts` file. The change adds a console log statement to display the current environment when initializing Datadog.

* [`src/utils/datadog.ts`](diffhunk://#diff-e6d498e4558d9849d4a0e014065f481982232fd4fc06566e2f53f5b8271f3b0bR28): Added a console log statement to print the current environment (`process.env.NODE_ENV`) during Datadog initialization.