### PR TITLE
chore: fix staging workflow

### DIFF
--- a/.github/workflows/build-and-deploy-staging.yml
+++ b/.github/workflows/build-and-deploy-staging.yml
@@ -39,6 +39,7 @@ jobs:
             - name: Build staging
               run: npm run build
               env:
+                  NODE_ENV: staging
                   R2_PROJECT_NAME: ${{ vars.R2_PROJECT_NAME }}
                   TRANSLATIONS_CDN_URL: ${{ vars.TRANSLATIONS_CDN_URL }}
                   CROWDIN_BRANCH_NAME: staging

--- a/src/utils/datadog.ts
+++ b/src/utils/datadog.ts
@@ -25,7 +25,6 @@ const getConfigValues = (is_production: boolean) => {
 
 const initDatadog = (is_datadog_enabled: boolean) => {
     if (!is_datadog_enabled) return;
-    console.log('current environment: ', process.env.NODE_ENV);
     if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'staging') {
         const is_production = process.env.NODE_ENV === 'production';
         const {


### PR DESCRIPTION
This pull request includes changes to the build and deployment process for the staging environment and some cleanup in the `datadog` utility file. The most important changes are listed below:

### Build and Deployment Process:

* [`.github/workflows/build-and-deploy-staging.yml`](diffhunk://#diff-b709f2739a5258d6c2c45e190ddc8e9329c2492822f44b593a8de5145e930b42R42): Added `NODE_ENV: staging` to the environment variables for the staging build job.

### Code Cleanup:

* [`src/utils/datadog.ts`](diffhunk://#diff-e6d498e4558d9849d4a0e014065f481982232fd4fc06566e2f53f5b8271f3b0bL28): Removed a console log statement that printed the current environment.