### PR TITLE
chore: check staging workflow with env vars

### DIFF
--- a/.github/workflows/build-and-deploy-staging.yml
+++ b/.github/workflows/build-and-deploy-staging.yml
@@ -39,6 +39,7 @@ jobs:
             - name: Build staging
               run: npm run build
               env:
+                  NODE_ENV: ${{ vars.NODE_ENV }}
                   R2_PROJECT_NAME: ${{ vars.R2_PROJECT_NAME }}
                   TRANSLATIONS_CDN_URL: ${{ vars.TRANSLATIONS_CDN_URL }}
                   CROWDIN_BRANCH_NAME: staging


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build-and-deploy-staging.yml` file. The change sets the `NODE_ENV` environment variable to use the value from the repository's variables.

* [`.github/workflows/build-and-deploy-staging.yml`](diffhunk://#diff-b709f2739a5258d6c2c45e190ddc8e9329c2492822f44b593a8de5145e930b42R42): Added `NODE_ENV` environment variable to the build staging job.