### PR TITLE
chore: fix staging workflow

### DIFF
--- a/.github/workflows/build-and-deploy-staging.yml
+++ b/.github/workflows/build-and-deploy-staging.yml
@@ -39,7 +39,6 @@ jobs:
             - name: Build staging
               run: npm run build
               env:
-                  NODE_ENV: ${{ vars.NODE_ENV }}
                   R2_PROJECT_NAME: ${{ vars.R2_PROJECT_NAME }}
                   TRANSLATIONS_CDN_URL: ${{ vars.TRANSLATIONS_CDN_URL }}
                   CROWDIN_BRANCH_NAME: staging


### PR DESCRIPTION
This pull request contains a small change to the `.github/workflows/build-and-deploy-staging.yml` file. The change involves removing the `NODE_ENV` environment variable from the build staging job.

* [`.github/workflows/build-and-deploy-staging.yml`](diffhunk://#diff-b709f2739a5258d6c2c45e190ddc8e9329c2492822f44b593a8de5145e930b42L42): Removed the `NODE_ENV` environment variable from the build staging job.