### PR TITLE
Farabi/bot-1887/trackjs-cannot-read-properties-of-null-connection

### DIFF
--- a/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_market.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_market.js
@@ -116,7 +116,9 @@ window.Blockly.Blocks.trade_definition_market = {
                 // Reconnect self to trade definition block.
                 if (trade_definition_block) {
                     const connection = trade_definition_block.getLastConnectionInStatement('TRADE_OPTIONS');
-                    connection.connect(this.previousConnection);
+                    if (connection) {
+                        connection.connect(this.previousConnection);
+                    }
                 } else {
                     this.dispose();
                 }


### PR DESCRIPTION
This pull request includes a small change to the `trade_definition_market.js` file. The change ensures that a connection is checked for existence before attempting to connect to it, preventing potential errors.

* [`src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_market.js`](diffhunk://#diff-a001fdc949d628b24f656d62bf1af2078329cde39d3bf773795bef2ec7aa4caaR119-R121): Added a check for the existence of `connection` before calling `connection.connect(this.previousConnection)`.