### PR TITLE
chore: fix staging workflow

### DIFF
--- a/.github/workflows/build-and-deploy-production.yml
+++ b/.github/workflows/build-and-deploy-production.yml
@@ -39,6 +39,7 @@ jobs:
             - name: Build Production
               run: npm run build
               env:
+                  APP_ENV: production
                   R2_PROJECT_NAME: ${{ vars.R2_PROJECT_NAME }}
                   TRANSLATIONS_CDN_URL: ${{ vars.TRANSLATIONS_CDN_URL }}
                   CROWDIN_BRANCH_NAME: production

--- a/.github/workflows/build-and-deploy-staging.yml
+++ b/.github/workflows/build-and-deploy-staging.yml
@@ -39,6 +39,7 @@ jobs:
             - name: Build staging
               run: npm run build
               env:
+                  APP_ENV: staging
                   R2_PROJECT_NAME: ${{ vars.R2_PROJECT_NAME }}
                   TRANSLATIONS_CDN_URL: ${{ vars.TRANSLATIONS_CDN_URL }}
                   CROWDIN_BRANCH_NAME: staging

--- a/src/hooks/growthbook/useRemoteConfig.ts
+++ b/src/hooks/growthbook/useRemoteConfig.ts
@@ -3,7 +3,7 @@ import { ObjectUtils } from '@deriv-com/utils';
 import initData from './remote_config.json';
 
 const remoteConfigQuery = async function () {
-    const isProductionOrStaging = process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'staging';
+    const isProductionOrStaging = process.env.APP_ENV === 'production' || process.env.APP_ENV === 'staging';
     const REMOTE_CONFIG_URL =
         process.env.REMOTE_CONFIG_URL ?? 'https://app-config-prod.firebaseio.com/remote_config/deriv-app.json';
     if (isProductionOrStaging && REMOTE_CONFIG_URL === '') {

--- a/src/hooks/useTrackjs.ts
+++ b/src/hooks/useTrackjs.ts
@@ -7,7 +7,7 @@ const { TRACKJS_TOKEN } = process.env;
  * @returns {Object} An object containing the `init` function.
  */
 const useTrackjs = () => {
-    const isProduction = process.env.NODE_ENV === 'production';
+    const isProduction = process.env.APP_ENV === 'production';
     const initTrackJS = (loginid: string) => {
         try {
             if (!TrackJS.isInstalled()) {

--- a/src/utils/analytics/index.ts
+++ b/src/utils/analytics/index.ts
@@ -30,7 +30,7 @@ export const AnalyticsInitializer = async () => {
                 growthbookDecryptionKey: flags.marketing_growthbook ? process.env.GROWTHBOOK_DECRYPTION_KEY : undefined,
                 rudderstackKey: process.env.RUDDERSTACK_KEY,
                 growthbookOptions: {
-                    disableCache: process.env.NODE_ENV !== 'production',
+                    disableCache: process.env.APP_ENV !== 'production',
                     attributes: {
                         account_type: account_type === 'null' ? 'unlogged' : account_type,
                         app_id: String(getAppId()),

--- a/src/utils/datadog.ts
+++ b/src/utils/datadog.ts
@@ -25,8 +25,8 @@ const getConfigValues = (is_production: boolean) => {
 
 const initDatadog = (is_datadog_enabled: boolean) => {
     if (!is_datadog_enabled) return;
-    if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'staging') {
-        const is_production = process.env.NODE_ENV === 'production';
+    if (process.env.APP_ENV === 'production' || process.env.APP_ENV === 'staging') {
+        const is_production = process.env.APP_ENV === 'production';
         const {
             service,
             version,


### PR DESCRIPTION
This pull request includes several changes to standardize the environment variable used to check the application environment across different parts of the codebase. The main change is the replacement of `process.env.NODE_ENV` with `process.env.APP_ENV`.

Environment variable standardization:

* [`.github/workflows/build-and-deploy-production.yml`](diffhunk://#diff-d8dfcbc7adf0e8cc7010e2eb020a5be671e7fed87aa32446ae7ef0e66fc1bfcaR42): Added `APP_ENV: production` to the environment variables in the build production job.
* [`.github/workflows/build-and-deploy-staging.yml`](diffhunk://#diff-b709f2739a5258d6c2c45e190ddc8e9329c2492822f44b593a8de5145e930b42R42): Added `APP_ENV: staging` to the environment variables in the build staging job.
* [`src/hooks/growthbook/useRemoteConfig.ts`](diffhunk://#diff-c9877b379cf20af88c35739b987212ed8869941066059c085e93ff3519822d2aL6-R6): Replaced `process.env.NODE_ENV` with `process.env.APP_ENV` in the `isProductionOrStaging` check.
* [`src/hooks/useTrackjs.ts`](diffhunk://#diff-a3c338371e016a85f1439b68696461946c57ff2fa5003033e90d48390d3a4d04L10-R10): Replaced `process.env.NODE_ENV` with `process.env.APP_ENV` in the `isProduction` check.
* [`src/utils/analytics/index.ts`](diffhunk://#diff-fadcf5cf714a4a5ebfb7f6a082cdf92be86bba68f1800a2e48803da059151a9fL33-R33): Replaced `process.env.NODE_ENV` with `process.env.APP_ENV` in the `disableCache` option.
* [`src/utils/datadog.ts`](diffhunk://#diff-e6d498e4558d9849d4a0e014065f481982232fd4fc06566e2f53f5b8271f3b0bL28-R29): Replaced `process.env.NODE_ENV` with `process.env.APP_ENV` in the `is_production` and `is_datadog_enabled` checks.