### PR TITLE
Rupato/check remove child error

### DIFF
--- a/src/components/shared_ui/modal/modal.tsx
+++ b/src/components/shared_ui/modal/modal.tsx
@@ -117,7 +117,12 @@ const ModalElement = ({
         onMount?.();
 
         return () => {
-            local_modal_root_ref?.current?.removeChild?.(local_el_ref.current);
+            const parent_element = local_modal_root_ref?.current;
+            const child_element = local_el_ref?.current;
+
+            if (parent_element && child_element && parent_element?.contains(child_element)) {
+                parent_element?.removeChild(child_element);
+            }
             onUnmount?.();
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/constants/load-modal.ts
+++ b/src/constants/load-modal.ts
@@ -7,7 +7,7 @@ export const tabs_title = Object.freeze({
 export const clearInjectionDiv = (el_ref?: HTMLElement) => {
     const parent_element = el_ref;
     const child_element = el_ref?.getElementsByClassName('injectionDiv');
-    if (parent_element && child_element && child_element.length > 1) {
+    if (parent_element && child_element && child_element?.length > 1) {
         parent_element.removeChild(child_element[0]);
     }
 };

--- a/src/constants/load-modal.ts
+++ b/src/constants/load-modal.ts
@@ -5,7 +5,9 @@ export const tabs_title = Object.freeze({
 });
 
 export const clearInjectionDiv = (el_ref?: HTMLElement) => {
-    if (el_ref && el_ref.getElementsByClassName('injectionDiv').length > 1) {
-        el_ref.removeChild(el_ref.getElementsByClassName('injectionDiv')[0]);
+    const parent_element = el_ref;
+    const child_element = el_ref?.getElementsByClassName('injectionDiv');
+    if (parent_element && child_element && child_element.length > 1) {
+        parent_element.removeChild(child_element[0]);
     }
 };

--- a/src/constants/load-modal.ts
+++ b/src/constants/load-modal.ts
@@ -8,6 +8,6 @@ export const clearInjectionDiv = (el_ref?: HTMLElement) => {
     const parent_element = el_ref;
     const child_element = el_ref?.getElementsByClassName('injectionDiv');
     if (parent_element && child_element && child_element?.length > 1) {
-        parent_element.removeChild(child_element[0]);
+        parent_element?.removeChild(child_element[0]);
     }
 };

--- a/src/external/bot-skeleton/scratch/backward-compatibility.js
+++ b/src/external/bot-skeleton/scratch/backward-compatibility.js
@@ -48,8 +48,12 @@ export default class BlockConversion {
 
                                 value_input.connection.connect(value_block.outputConnection);
                             });
+                            const parent_element = child_node.parentNode;
+                            const child_element = child_node;
 
-                            child_node.parentNode.removeChild(child_node);
+                            if (parent_element && child_element && parent_element?.contains(child_element)) {
+                                parent_element?.removeChild(child_element);
+                            }
                         });
                 }
             }
@@ -135,8 +139,12 @@ export default class BlockConversion {
 
                                 value_input.connection.connect(converted_block.outputConnection);
                             });
+                            const parent_element = el_value?.parentNode;
+                            const child_element = el_value;
 
-                            el_value.parentNode.removeChild(el_value);
+                            if (parent_element && child_element && parent_element?.contains(child_element)) {
+                                el_value?.parentNode?.removeChild(el_value);
+                            }
                         }
                     });
                 }

--- a/src/external/bot-skeleton/scratch/goog.js
+++ b/src/external/bot-skeleton/scratch/goog.js
@@ -31,8 +31,11 @@ goog.isNumber = function (e) {
 goog.dom = {};
 
 goog.dom.removeNode = function (node) {
-    if (node && node.parentNode) {
-        node.parentNode.removeChild(node);
+    const parent_element = node.parentNode;
+    const child_element = node;
+
+    if (child_element && parent_element) {
+        parent_element.removeChild(child_element);
     }
 };
 

--- a/src/external/bot-skeleton/scratch/goog.js
+++ b/src/external/bot-skeleton/scratch/goog.js
@@ -34,8 +34,8 @@ goog.dom.removeNode = function (node) {
     const parent_element = node.parentNode;
     const child_element = node;
 
-    if (child_element && parent_element && parent_element.contains(child_element)) {
-        parent_element.removeChild(child_element);
+    if (child_element && parent_element && parent_element?.contains(child_element)) {
+        parent_element?.removeChild(child_element);
     }
 };
 

--- a/src/external/bot-skeleton/scratch/goog.js
+++ b/src/external/bot-skeleton/scratch/goog.js
@@ -34,7 +34,7 @@ goog.dom.removeNode = function (node) {
     const parent_element = node.parentNode;
     const child_element = node;
 
-    if (child_element && parent_element) {
+    if (child_element && parent_element && parent_element.contains(child_element)) {
         parent_element.removeChild(child_element);
     }
 };

--- a/src/pages/tutorials/tutorials-tab-mobile.tsx
+++ b/src/pages/tutorials/tutorials-tab-mobile.tsx
@@ -69,7 +69,7 @@ const TutorialsTabMobile = observer(({ tutorial_tabs, prev_active_tutorials }: T
 
         if (selectElement) {
             const parent_element = selectElement;
-            const child_element = selectElement?.options[3];
+            const child_element = selectElement?.options?.[3];
 
             if (parent_element && child_element && parent_element?.contains(child_element)) {
                 parent_element?.removeChild(child_element);

--- a/src/pages/tutorials/tutorials-tab-mobile.tsx
+++ b/src/pages/tutorials/tutorials-tab-mobile.tsx
@@ -68,7 +68,12 @@ const TutorialsTabMobile = observer(({ tutorial_tabs, prev_active_tutorials }: T
         const selectElement = document.getElementById('dt_components_select-native_select-tag') as HTMLSelectElement;
 
         if (selectElement) {
-            selectElement.removeChild(selectElement?.options[3]);
+            const parent_element = selectElement;
+            const child_element = selectElement?.options[3];
+
+            if (parent_element && child_element && parent_element.contains(child_element)) {
+                parent_element?.removeChild(child_element);
+            }
         }
     }, []);
 

--- a/src/pages/tutorials/tutorials-tab-mobile.tsx
+++ b/src/pages/tutorials/tutorials-tab-mobile.tsx
@@ -71,7 +71,7 @@ const TutorialsTabMobile = observer(({ tutorial_tabs, prev_active_tutorials }: T
             const parent_element = selectElement;
             const child_element = selectElement?.options[3];
 
-            if (parent_element && child_element && parent_element.contains(child_element)) {
+            if (parent_element && child_element && parent_element?.contains(child_element)) {
                 parent_element?.removeChild(child_element);
             }
         }

--- a/src/stores/google-drive-store.ts
+++ b/src/stores/google-drive-store.ts
@@ -190,8 +190,8 @@ export default class GoogleDriveStore {
                 const picker = document.getElementsByClassName('picker-dialog-content')[0] as HTMLElement;
                 const parent_element = picker?.parentNode;
                 const child_element = picker;
-                if (child_element && parent_element && parent_element.contains(child_element)) {
-                    parent_element.removeChild(child_element);
+                if (child_element && parent_element && parent_element?.contains(child_element)) {
+                    parent_element?.removeChild(child_element);
                 }
                 picker?.parentNode?.removeChild(picker);
                 const pickerBackground = document.getElementsByClassName(

--- a/src/stores/google-drive-store.ts
+++ b/src/stores/google-drive-store.ts
@@ -188,6 +188,11 @@ export default class GoogleDriveStore {
             if ((err as TErrorWithStatus)?.status === 401) {
                 await this.signOut();
                 const picker = document.getElementsByClassName('picker-dialog-content')[0] as HTMLElement;
+                const parent_element = picker?.parentNode;
+                const child_element = picker;
+                if (child_element && parent_element && parent_element.contains(child_element)) {
+                    parent_element.removeChild(child_element);
+                }
                 picker?.parentNode?.removeChild(picker);
                 const pickerBackground = document.getElementsByClassName(
                     'picker-dialog-bg'

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -92,5 +92,9 @@ export const downloadFile = (file_name: string, content: string) => {
     link.setAttribute('download', `${file_name} ${getCurrentDateTimeLocale()}.csv`);
     document.body.appendChild(link);
     link.click();
-    link.parentNode?.removeChild(link);
+    const parent_element = link.parentNode;
+    const child_element = link;
+    if (parent_element && child_element && parent_element.contains(child_element)) {
+        parent_element.removeChild(child_element);
+    }
 };

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -94,7 +94,7 @@ export const downloadFile = (file_name: string, content: string) => {
     link.click();
     const parent_element = link.parentNode;
     const child_element = link;
-    if (parent_element && child_element && parent_element.contains(child_element)) {
-        parent_element.removeChild(child_element);
+    if (parent_element && child_element && parent_element?.contains(child_element)) {
+        parent_element?.removeChild(child_element);
     }
 };


### PR DESCRIPTION
This pull request focuses on improving the robustness of element removal in various parts of the codebase by ensuring the parent element contains the child element before attempting to remove it. The most important changes include modifications in multiple files to implement this check.

Element removal improvements:

* [`src/components/shared_ui/modal/modal.tsx`](diffhunk://#diff-2f01ecbfac1995244232f0ba0a2a37879a380a96a8fa5bf8525164858c6b6cf9L120-R125): Added checks to ensure the parent element contains the child element before removing it in the `ModalElement` component.
* [`src/constants/load-modal.ts`](diffhunk://#diff-8e8cfb817626d60bb7ddcaffb193fdf51d4a55ac594cf65eb2b60ccb1d1138ccL8-R11): Enhanced the `clearInjectionDiv` function by adding checks to ensure the parent element contains the child element before removal.
* [`src/external/bot-skeleton/scratch/backward-compatibility.js`](diffhunk://#diff-3e873f203d283281d1b2de88bb09d11e31c7878e432005a78cc85cc9df590212R51-R56): Updated the `BlockConversion` class to include checks before removing child elements in two different locations. [[1]](diffhunk://#diff-3e873f203d283281d1b2de88bb09d11e31c7878e432005a78cc85cc9df590212R51-R56) [[2]](diffhunk://#diff-3e873f203d283281d1b2de88bb09d11e31c7878e432005a78cc85cc9df590212R142-R147)
* [`src/external/bot-skeleton/scratch/goog.js`](diffhunk://#diff-eec5ba1db688a59e129cd50b0e6a9dfa240a4c2b9d63715571c2d4c1d2ffaa1aL34-R38): Modified the `goog.dom.removeNode` function to ensure the parent element contains the child element before removal.
* [`src/pages/tutorials/tutorials-tab-mobile.tsx`](diffhunk://#diff-59f21872452003d32832d2f9b7f72493531574f1a22988fe140363ab1bf8e340L71-R76): Added checks in the `TutorialsTabMobile` component to ensure the parent element contains the child element before removing it.