### PR TITLE
fix: multiplier stop loss block

### DIFF
--- a/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
@@ -336,11 +336,11 @@ window.Blockly.Blocks.trade_definition_tradeoptions = {
                     take_profit_shadow_block.initSvg();
                     take_profit_shadow_block.renderEfficiently();
 
+                    take_profit_block.initSvg();
+                    take_profit_block.renderEfficiently();
                     multiplier_block
                         .getLastConnectionInStatement('MULTIPLIER_PARAMS')
                         .connect(take_profit_block.previousConnection);
-                    take_profit_block.initSvg();
-                    take_profit_block.renderEfficiently();
 
                     const stop_loss_block = this.workspace.newBlock('multiplier_stop_loss');
                     const stop_loss_input = stop_loss_block.getInput('AMOUNT');

--- a/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
@@ -353,11 +353,11 @@ window.Blockly.Blocks.trade_definition_tradeoptions = {
                     stop_loss_shadow_block.initSvg();
                     stop_loss_shadow_block.renderEfficiently();
 
+                    stop_loss_block.initSvg();
+                    stop_loss_block.renderEfficiently();
                     multiplier_block
                         .getLastConnectionInStatement('MULTIPLIER_PARAMS')
                         .connect(stop_loss_block.previousConnection);
-                    stop_loss_block.initSvg();
-                    stop_loss_block.renderEfficiently();
 
                     this.dispose();
                 });


### PR DESCRIPTION
This pull request includes a minor change to the `trade_definition_tradeoptions.js` file. The change ensures that the `stop_loss_block` is initialized and rendered before it is connected to the `multiplier_block`.

* [`src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js`](diffhunk://#diff-ddafb9ecab3f17ca1d9362d1c8e8d083b398ceb8b563eb1ee516fc999900d012R356-L360): Moved the initialization and rendering of `stop_loss_block` before its connection to `multiplier_block` to ensure proper execution order.