### PR TITLE
fix: hotfix active symbol issue

### DIFF
--- a/src/app/app-content.jsx
+++ b/src/app/app-content.jsx
@@ -122,15 +122,26 @@ const AppContent = observer(() => {
 
     const changeActiveSymbolLoadingState = () => {
         init();
-        const intervalId = setInterval(() => {
-            if (ApiHelpers?.instance?.active_symbols) {
-                clearInterval(intervalId);
-                const { active_symbols } = ApiHelpers.instance;
-                active_symbols.retrieveActiveSymbols(true).then(() => {
-                    setIsLoading(false);
-                });
-            }
-        }, 1000);
+
+        const retrieveActiveSymbols = () => {
+            const { active_symbols } = ApiHelpers.instance;
+            active_symbols.retrieveActiveSymbols(true).then(() => {
+                setIsLoading(false);
+            });
+        };
+
+        if (ApiHelpers?.instance?.active_symbols) {
+            retrieveActiveSymbols();
+        } else {
+            // This is a workaround to fix the issue where the active symbols are not loaded immediately
+            // when the API is initialized. Should be replaced with RxJS pubsub
+            const intervalId = setInterval(() => {
+                if (ApiHelpers?.instance?.active_symbols) {
+                    clearInterval(intervalId);
+                    retrieveActiveSymbols();
+                }
+            }, 1000);
+        }
     };
 
     React.useEffect(() => {

--- a/src/external/bot-skeleton/scratch/backward-compatibility.js
+++ b/src/external/bot-skeleton/scratch/backward-compatibility.js
@@ -275,7 +275,9 @@ export default class BlockConversion {
         // Legacy symbol + trade_type blocks are special cases, they are turned into multiple blocks.
         // We don't convert these atm, as a workaround users can import to BBot, then export and load
         // into DBot.
-        const { active_symbols } = ApiHelpers.instance.active_symbols;
+        const { active_symbols } = ApiHelpers?.instance?.active_symbols ?? {
+            active_symbols: [],
+        };
         const { opposites } = config();
 
         active_symbols.forEach(active_symbol => {

--- a/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_accumulator.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_accumulator.js
@@ -175,10 +175,10 @@ window.Blockly.Blocks.trade_definition_accumulator = {
     },
     updateAmountLimits: window.Blockly.Blocks.trade_definition_tradeoptions.updateAmountLimits,
     updateAccumulatorInput(should_use_default_value) {
-        const { contracts_for } = ApiHelpers.instance;
+        const { contracts_for } = ApiHelpers?.instance ?? {};
 
         if (this.selected_trade_type === 'accumulator') {
-            contracts_for.getAccumulationRange().then(accumulator_range => {
+            contracts_for?.getAccumulationRange?.()?.then(accumulator_range => {
                 if (accumulator_range.length > 0) {
                     const accumulator_list_dropdown = this.getField('GROWTHRATE_LIST');
                     const accumulator_options = accumulator_range.map(value => {

--- a/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_market.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_market.js
@@ -57,7 +57,9 @@ window.Blockly.Blocks.trade_definition_market = {
 
         this.enforceLimitations();
 
-        const { active_symbols } = ApiHelpers.instance;
+        const { active_symbols } = ApiHelpers?.instance ?? {};
+        if (!active_symbols) return;
+
         const market_dropdown = this.getField('MARKET_LIST');
         const submarket_dropdown = this.getField('SUBMARKET_LIST');
         const symbol_dropdown = this.getField('SYMBOL_LIST');

--- a/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_multiplier.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_multiplier.js
@@ -182,22 +182,24 @@ window.Blockly.Blocks.trade_definition_multiplier = {
     },
 
     updateMultiplierInput(should_use_default_value) {
-        const { contracts_for } = ApiHelpers.instance;
+        const { contracts_for } = ApiHelpers?.instance ?? {};
 
         if (this.selected_trade_type === 'multiplier') {
-            contracts_for.getMultiplierRange(this.selected_symbol, this.selected_trade_type).then(multiplier_range => {
-                if (multiplier_range.length > 0) {
-                    const multiplier_list_dropdown = this.getField('MULTIPLIERTYPE_LIST');
-                    const multiplier_options = multiplier_range.map(value => {
-                        const option = value.toString();
-                        return [option, option];
-                    });
+            contracts_for
+                ?.getMultiplierRange?.(this.selected_symbol, this.selected_trade_type)
+                ?.then(multiplier_range => {
+                    if (multiplier_range.length > 0) {
+                        const multiplier_list_dropdown = this.getField('MULTIPLIERTYPE_LIST');
+                        const multiplier_options = multiplier_range.map(value => {
+                            const option = value.toString();
+                            return [option, option];
+                        });
 
-                    multiplier_list_dropdown?.updateOptions(multiplier_options, {
-                        default_value: should_use_default_value ? undefined : multiplier_list_dropdown.getValue(),
-                    });
-                }
-            });
+                        multiplier_list_dropdown?.updateOptions(multiplier_options, {
+                            default_value: should_use_default_value ? undefined : multiplier_list_dropdown.getValue(),
+                        });
+                    }
+                });
             return;
         }
 

--- a/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
@@ -237,7 +237,8 @@ window.Blockly.Blocks.trade_definition_tradeoptions = {
         });
     },
     updateAmountLimits() {
-        const { account_limits } = ApiHelpers.instance;
+        const { account_limits } = ApiHelpers?.instance ?? {};
+        if (!account_limits) return;
         const { currency, landing_company_shortcode } = DBotStore.instance.client;
         if (isAuthorizing$.getValue()) return;
         account_limits.getStakePayoutLimits(currency, landing_company_shortcode, this.selected_market).then(limits => {
@@ -260,7 +261,8 @@ window.Blockly.Blocks.trade_definition_tradeoptions = {
         });
     },
     updateDurationInput(should_use_default_unit, should_update_value) {
-        const { contracts_for } = ApiHelpers.instance;
+        const { contracts_for } = ApiHelpers?.instance ?? {};
+        if (!contracts_for) return;
 
         if (this.selected_trade_type === 'accumulator' && this.isDescendantOf('trade_definition')) {
             runIrreversibleEvents(() => {
@@ -400,7 +402,9 @@ window.Blockly.Blocks.trade_definition_tradeoptions = {
         }, 10);
     },
     updateBarrierInputs(should_use_default_type, should_use_default_values) {
-        const { contracts_for } = ApiHelpers.instance;
+        const { contracts_for } = ApiHelpers?.instance ?? {};
+        if (!contracts_for) return;
+
         const { BARRIER_TYPES } = config();
 
         contracts_for
@@ -458,7 +462,8 @@ window.Blockly.Blocks.trade_definition_tradeoptions = {
             });
     },
     updatePredictionInput(should_use_default_value) {
-        const { contracts_for } = ApiHelpers.instance;
+        const { contracts_for } = ApiHelpers?.instance ?? {};
+        if (!contracts_for) return;
 
         contracts_for.getPredictionRange(this.selected_symbol, this.selected_trade_type).then(prediction_range => {
             this.createPredictionInput(prediction_range);

--- a/src/external/bot-skeleton/scratch/dbot.js
+++ b/src/external/bot-skeleton/scratch/dbot.js
@@ -45,7 +45,7 @@ class DBot {
                 const is_trade_type_cat_list_change = name === 'TRADETYPECAT_LIST';
 
                 if (is_symbol_list_change || is_trade_type_cat_list_change) {
-                    const { contracts_for } = ApiHelpers.instance;
+                    const { contracts_for } = ApiHelpers?.instance ?? {};
                     const top_parent_block = this.getTopParent();
                     const market_block = top_parent_block.getChildByType('trade_definition_market');
                     const market = market_block.getFieldValue('MARKET_LIST');
@@ -57,7 +57,7 @@ class DBot {
                     if (!is_trade_type_accumulator) forgetAccumulatorsProposalRequest(that);
 
                     if (is_symbol_list_change) {
-                        contracts_for.getTradeTypeCategories(market, submarket, symbol).then(categories => {
+                        contracts_for?.getTradeTypeCategories?.(market, submarket, symbol).then(categories => {
                             const category_field = this.getField('TRADETYPECAT_LIST');
                             if (category_field) {
                                 category_field.updateOptions(categories, {
@@ -82,7 +82,7 @@ class DBot {
                             });
                         }
                     } else if (is_trade_type_cat_list_change && event.blockId === this.id) {
-                        contracts_for.getTradeTypes(market, submarket, symbol, category).then(trade_types => {
+                        contracts_for?.getTradeTypes?.(market, submarket, symbol, category).then(trade_types => {
                             const trade_type_field = this.getField('TRADETYPE_LIST');
                             trade_type_field.updateOptions(trade_types, {
                                 default_value: trade_type,

--- a/src/external/bot-skeleton/services/api/api-helpers.js
+++ b/src/external/bot-skeleton/services/api/api-helpers.js
@@ -26,7 +26,7 @@ class ApiHelpers {
     }
 
     static get instance() {
-        return this.singleton ?? {};
+        return this.singleton;
     }
 }
 

--- a/src/pages/bot-builder/quick-strategy/selects/contract-type.tsx
+++ b/src/pages/bot-builder/quick-strategy/selects/contract-type.tsx
@@ -27,8 +27,8 @@ const ContractTypes: React.FC<TContractTypes> = observer(({ name }) => {
         if (tradetype && symbol) {
             const selected = values?.type;
             const getContractTypes = async () => {
-                const { contracts_for } = ApiHelpers.instance as unknown as TApiHelpersInstance;
-                const categories = await contracts_for.getContractTypes(tradetype);
+                const { contracts_for } = (ApiHelpers?.instance as unknown as TApiHelpersInstance) ?? {};
+                const categories = await contracts_for?.getContractTypes?.(tradetype);
                 setList(categories);
                 const has_selected = categories?.some(contract => contract.value === selected);
                 if (!has_selected) {

--- a/src/pages/bot-builder/quick-strategy/selects/duration-type.tsx
+++ b/src/pages/bot-builder/quick-strategy/selects/duration-type.tsx
@@ -23,8 +23,8 @@ const DurationUnit: React.FC<TDurationUnit> = ({ attached }: TDurationUnit) => {
     React.useEffect(() => {
         if (tradetype && symbol) {
             const getDurationUnits = async () => {
-                const { contracts_for } = ApiHelpers.instance as unknown as TApiHelpersInstance;
-                const durations = await contracts_for.getDurations(symbol, tradetype);
+                const { contracts_for } = (ApiHelpers?.instance as unknown as TApiHelpersInstance) ?? {};
+                const durations = await contracts_for?.getDurations?.(symbol, tradetype);
                 const duration_units = durations?.map(duration => ({
                     text: duration.display ?? '',
                     value: duration.unit ?? '',

--- a/src/pages/bot-builder/quick-strategy/selects/symbol.tsx
+++ b/src/pages/bot-builder/quick-strategy/selects/symbol.tsx
@@ -53,12 +53,13 @@ const SymbolSelect: React.FC = () => {
     );
 
     useEffect(() => {
-        const { active_symbols } = ApiHelpers.instance as unknown as {
-            active_symbols: {
-                getSymbolsForBot: () => TSymbol[];
-            };
-        };
-        const symbols = active_symbols.getSymbolsForBot();
+        const { active_symbols } =
+            (ApiHelpers?.instance as unknown as {
+                active_symbols: {
+                    getSymbolsForBot: () => TSymbol[];
+                };
+            }) ?? {};
+        const symbols = active_symbols?.getSymbolsForBot?.();
         setActiveSymbols(symbols);
 
         const has_symbol = !!symbols?.find(symbol => symbol?.value === values?.symbol);

--- a/src/pages/bot-builder/quick-strategy/selects/trade-type.tsx
+++ b/src/pages/bot-builder/quick-strategy/selects/trade-type.tsx
@@ -40,9 +40,9 @@ const TradeTypeSelect: React.FC = () => {
             const selected = values?.tradetype;
             const is_symbol_accumulator = is_strategy_accumulator ? 'ACCU' : '';
 
-            const { contracts_for } = ApiHelpers.instance as unknown as TApiHelpersInstance;
+            const { contracts_for } = (ApiHelpers?.instance as unknown as TApiHelpersInstance) ?? {};
             const getTradeTypes = async () => {
-                const trade_types = await contracts_for.getTradeTypesForQuickStrategy(
+                const trade_types = await contracts_for?.getTradeTypesForQuickStrategy?.(
                     values?.symbol,
                     is_symbol_accumulator
                 );

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -253,16 +253,16 @@ export default class AppStore {
                     ws: api_base.api,
                 };
 
-                if (!ApiHelpers.instance) {
+                if (!ApiHelpers?.instance) {
                     ApiHelpers.setInstance(this.api_helpers_store);
                 }
 
                 this.showDigitalOptionsMaltainvestError();
 
-                const active_symbols = ApiHelpers.instance?.active_symbols;
-                const contracts_for = ApiHelpers.instance?.contracts_for;
+                const active_symbols = ApiHelpers?.instance?.active_symbols;
+                const contracts_for = ApiHelpers?.instance?.contracts_for;
 
-                if (ApiHelpers.instance && active_symbols && contracts_for) {
+                if (ApiHelpers?.instance && active_symbols && contracts_for) {
                     if (window.Blockly?.derivWorkspace) {
                         active_symbols?.retrieveActiveSymbols(true).then(() => {
                             contracts_for.disposeCache();

--- a/src/stores/quick-strategy-store.ts
+++ b/src/stores/quick-strategy-store.ts
@@ -140,7 +140,8 @@ export default class QuickStrategyStore implements IQuickStrategyStore {
     };
 
     onSubmit = async (data: TFormData) => {
-        const { contracts_for } = ApiHelpers.instance;
+        const { contracts_for } = ApiHelpers?.instance ?? {};
+        if (!contracts_for) return;
         const market = await contracts_for.getMarketBySymbol(data.symbol);
         const submarket = await contracts_for.getSubmarketBySymbol(data.symbol);
         const trade_type_cat = await contracts_for.getTradeTypeCategoryByTradeType(data.tradetype);


### PR DESCRIPTION
This pull request focuses on improving the robustness of the code by adding nullish coalescing and optional chaining operators to various instances of `ApiHelpers`. These changes ensure that the application handles cases where `ApiHelpers` or its properties might be undefined, preventing potential runtime errors.

Key changes include:

### Robustness Improvements:
* [`src/app/app-content.jsx`](diffhunk://#diff-acb1b12c8798bdef78154e1bcbb70ce985402145ca80e436a5886cb66afed67fL125-R144): Replaced the interval-based loading of active symbols with a function that checks if `ApiHelpers.instance.active_symbols` is available and retrieves active symbols accordingly. Added a workaround for cases where active symbols are not immediately loaded.

* [`src/external/bot-skeleton/scratch/backward-compatibility.js`](diffhunk://#diff-3e873f203d283281d1b2de88bb09d11e31c7878e432005a78cc85cc9df590212L278-R280): Added nullish coalescing to handle cases where `ApiHelpers.instance.active_symbols` might be undefined.

* [`src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_accumulator.js`](diffhunk://#diff-8057e3053a08831592b7f82b1cef401bd6af376e21c1c6c1f9cf751ddb8de0c4L178-R181): Used optional chaining to safely access `contracts_for` and its methods.

* [`src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_market.js`](diffhunk://#diff-a001fdc949d628b24f656d62bf1af2078329cde39d3bf773795bef2ec7aa4caaL60-R62): Added nullish coalescing and a return statement to handle undefined `active_symbols`.

* [`src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js`](diffhunk://#diff-ddafb9ecab3f17ca1d9362d1c8e8d083b398ceb8b563eb1ee516fc999900d012L240-R241): Applied nullish coalescing and optional chaining to various instances of `contracts_for` and `account_limits` to ensure safe access. [[1]](diffhunk://#diff-ddafb9ecab3f17ca1d9362d1c8e8d083b398ceb8b563eb1ee516fc999900d012L240-R241) [[2]](diffhunk://#diff-ddafb9ecab3f17ca1d9362d1c8e8d083b398ceb8b563eb1ee516fc999900d012L263-R265) [[3]](diffhunk://#diff-ddafb9ecab3f17ca1d9362d1c8e8d083b398ceb8b563eb1ee516fc999900d012L403-R407) [[4]](diffhunk://#diff-ddafb9ecab3f17ca1d9362d1c8e8d083b398ceb8b563eb1ee516fc999900d012L461-R466)