### PR TITLE
fix: removed disable option in trade parameters blocks

### DIFF
--- a/src/external/bot-skeleton/scratch/blocks/Binary/Before Purchase/before_purchase.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Before Purchase/before_purchase.js
@@ -1,5 +1,5 @@
 import { localize } from '@deriv-com/translations';
-import { appendCollapsedMainBlocksFields, modifyContextMenu } from '../../../utils';
+import { appendCollapsedMainBlocksFields, excludeOptionFromContextMenu, modifyContextMenu } from '../../../utils';
 import { purchase } from '../../images';
 
 window.Blockly.Blocks.before_purchase = {
@@ -62,6 +62,8 @@ window.Blockly.Blocks.before_purchase = {
         }
     },
     customContextMenu(menu) {
+        const menu_items = [localize('Enable Block'), localize('Disable Block')];
+        excludeOptionFromContextMenu(menu, menu_items);
         modifyContextMenu(menu);
     },
     meta() {

--- a/src/external/bot-skeleton/scratch/blocks/Binary/Before Purchase/purchase.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Before Purchase/purchase.js
@@ -1,6 +1,6 @@
 import { localize } from '@deriv-com/translations';
 import { getContractTypeOptions } from '../../../shared';
-import { modifyContextMenu } from '../../../utils';
+import { excludeOptionFromContextMenu, modifyContextMenu } from '../../../utils';
 
 window.Blockly.Blocks.purchase = {
     init() {
@@ -76,6 +76,8 @@ window.Blockly.Blocks.purchase = {
         }
     },
     customContextMenu(menu) {
+        const menu_items = [localize('Enable Block'), localize('Disable Block')];
+        excludeOptionFromContextMenu(menu, menu_items);
         modifyContextMenu(menu);
     },
     restricted_parents: ['before_purchase'],

--- a/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition.js
@@ -2,7 +2,12 @@ import { localize } from '@deriv-com/translations';
 import { config } from '../../../../constants/config';
 import { initErrorHandlingListener, removeErrorHandlingEventListener } from '../../../../utils';
 import DBotStore from '../../../dbot-store';
-import { appendCollapsedMainBlocksFields, modifyContextMenu, runIrreversibleEvents } from '../../../utils';
+import {
+    appendCollapsedMainBlocksFields,
+    excludeOptionFromContextMenu,
+    modifyContextMenu,
+    runIrreversibleEvents,
+} from '../../../utils';
 import { defineContract } from '../../images';
 
 window.Blockly.Blocks.trade_definition = {
@@ -111,6 +116,8 @@ window.Blockly.Blocks.trade_definition = {
         };
     },
     customContextMenu(menu) {
+        const menu_items = [localize('Enable Block'), localize('Disable Block')];
+        excludeOptionFromContextMenu(menu, menu_items);
         modifyContextMenu(menu);
     },
     onchange(event) {

--- a/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_accumulator.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_accumulator.js
@@ -4,7 +4,13 @@ import { config } from '../../../../constants/config';
 import ApiHelpers from '../../../../services/api/api-helpers';
 import { handleProposalRequestForAccumulators } from '../../../accumulators-proposal-handler';
 import DBotStore from '../../../dbot-store';
-import { modifyContextMenu, runGroupedEvents, runIrreversibleEvents, setCurrency } from '../../../utils';
+import {
+    excludeOptionFromContextMenu,
+    modifyContextMenu,
+    runGroupedEvents,
+    runIrreversibleEvents,
+    setCurrency,
+} from '../../../utils';
 
 window.Blockly.Blocks.trade_definition_accumulator = {
     init() {
@@ -236,6 +242,8 @@ window.Blockly.Blocks.trade_definition_accumulator = {
         }
     },
     customContextMenu(menu) {
+        const menu_items = [localize('Enable Block'), localize('Disable Block')];
+        excludeOptionFromContextMenu(menu, menu_items);
         modifyContextMenu(menu);
     },
     restricted_parents: ['trade_definition'],

--- a/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_candleinterval.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_candleinterval.js
@@ -1,6 +1,6 @@
 import { localize } from '@deriv-com/translations';
 import { config } from '../../../../constants/config';
-import { modifyContextMenu } from '../../../utils';
+import { excludeOptionFromContextMenu, modifyContextMenu } from '../../../utils';
 
 window.Blockly.Blocks.trade_definition_candleinterval = {
     init() {
@@ -31,6 +31,8 @@ window.Blockly.Blocks.trade_definition_candleinterval = {
         this.enforceLimitations();
     },
     customContextMenu(menu) {
+        const menu_items = [localize('Enable Block'), localize('Disable Block')];
+        excludeOptionFromContextMenu(menu, menu_items);
         modifyContextMenu(menu);
     },
     enforceLimitations: window.Blockly.Blocks.trade_definition_market.enforceLimitations,

--- a/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_contracttype.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_contracttype.js
@@ -1,7 +1,7 @@
 import { localize } from '@deriv-com/translations';
 import { config } from '../../../../constants/config';
 import { getContractTypeOptions } from '../../../shared';
-import { modifyContextMenu } from '../../../utils';
+import { excludeOptionFromContextMenu, modifyContextMenu } from '../../../utils';
 
 window.Blockly.Blocks.trade_definition_contracttype = {
     init() {
@@ -61,6 +61,8 @@ window.Blockly.Blocks.trade_definition_contracttype = {
         }
     },
     customContextMenu(menu) {
+        const menu_items = [localize('Enable Block'), localize('Disable Block')];
+        excludeOptionFromContextMenu(menu, menu_items);
         modifyContextMenu(menu);
     },
     enforceLimitations: window.Blockly.Blocks.trade_definition_market.enforceLimitations,

--- a/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_market.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_market.js
@@ -1,6 +1,6 @@
 import { localize } from '@deriv-com/translations';
 import ApiHelpers from '../../../../services/api/api-helpers';
-import { modifyContextMenu, runIrreversibleEvents } from '../../../utils';
+import { excludeOptionFromContextMenu, modifyContextMenu, runIrreversibleEvents } from '../../../utils';
 
 /* eslint-disable */
 window.Blockly.Blocks.trade_definition_market = {
@@ -39,6 +39,8 @@ window.Blockly.Blocks.trade_definition_market = {
         this.setDeletable(false);
     },
     customContextMenu(menu) {
+        const menu_items = [localize('Enable Block'), localize('Disable Block')];
+        excludeOptionFromContextMenu(menu, menu_items);
         modifyContextMenu(menu);
     },
     onchange(event) {

--- a/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_multiplier.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_multiplier.js
@@ -3,7 +3,13 @@ import { localize } from '@deriv-com/translations';
 import { config } from '../../../../constants/config';
 import ApiHelpers from '../../../../services/api/api-helpers';
 import DBotStore from '../../../dbot-store';
-import { modifyContextMenu, runGroupedEvents, runIrreversibleEvents, setCurrency } from '../../../utils';
+import {
+    excludeOptionFromContextMenu,
+    modifyContextMenu,
+    runGroupedEvents,
+    runIrreversibleEvents,
+    setCurrency,
+} from '../../../utils';
 
 window.Blockly.Blocks.trade_definition_multiplier = {
     init() {
@@ -245,6 +251,8 @@ window.Blockly.Blocks.trade_definition_multiplier = {
         }
     },
     customContextMenu(menu) {
+        const menu_items = [localize('Enable Block'), localize('Disable Block')];
+        excludeOptionFromContextMenu(menu, menu_items);
         modifyContextMenu(menu);
     },
     restricted_parents: ['trade_definition'],

--- a/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_restartbuysell.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_restartbuysell.js
@@ -1,5 +1,5 @@
 import { localize } from '@deriv-com/translations';
-import { modifyContextMenu } from '../../../utils';
+import { excludeOptionFromContextMenu, modifyContextMenu } from '../../../utils';
 
 window.Blockly.Blocks.trade_definition_restartbuysell = {
     init() {
@@ -39,6 +39,8 @@ window.Blockly.Blocks.trade_definition_restartbuysell = {
         this.enforceLimitations();
     },
     customContextMenu(menu) {
+        const menu_items = [localize('Enable Block'), localize('Disable Block')];
+        excludeOptionFromContextMenu(menu, menu_items);
         modifyContextMenu(menu);
     },
     enforceLimitations: window.Blockly.Blocks.trade_definition_market.enforceLimitations,

--- a/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_restartonerror.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_restartonerror.js
@@ -1,5 +1,5 @@
 import { localize } from '@deriv-com/translations';
-import { modifyContextMenu } from '../../../utils';
+import { excludeOptionFromContextMenu, modifyContextMenu } from '../../../utils';
 
 window.Blockly.Blocks.trade_definition_restartonerror = {
     init() {
@@ -34,6 +34,8 @@ window.Blockly.Blocks.trade_definition_restartonerror = {
         this.enforceLimitations();
     },
     customContextMenu(menu) {
+        const menu_items = [localize('Enable Block'), localize('Disable Block')];
+        excludeOptionFromContextMenu(menu, menu_items);
         modifyContextMenu(menu);
     },
     enforceLimitations: window.Blockly.Blocks.trade_definition_market.enforceLimitations,

--- a/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
@@ -4,7 +4,13 @@ import { localize } from '@deriv-com/translations';
 import { config } from '../../../../constants/config';
 import ApiHelpers from '../../../../services/api/api-helpers';
 import DBotStore from '../../../dbot-store';
-import { modifyContextMenu, runGroupedEvents, runIrreversibleEvents, setCurrency } from '../../../utils';
+import {
+    excludeOptionFromContextMenu,
+    modifyContextMenu,
+    runGroupedEvents,
+    runIrreversibleEvents,
+    setCurrency,
+} from '../../../utils';
 
 window.Blockly.Blocks.trade_definition_tradeoptions = {
     durations: [],
@@ -70,6 +76,8 @@ window.Blockly.Blocks.trade_definition_tradeoptions = {
         };
     },
     customContextMenu(menu) {
+        const menu_items = [localize('Enable Block'), localize('Disable Block')];
+        excludeOptionFromContextMenu(menu, menu_items);
         modifyContextMenu(menu);
     },
     onchange(event) {

--- a/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_tradetype.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_tradetype.js
@@ -1,5 +1,5 @@
 import { localize } from '@deriv-com/translations';
-import { modifyContextMenu } from '../../../utils';
+import { excludeOptionFromContextMenu, modifyContextMenu } from '../../../utils';
 
 window.Blockly.Blocks.trade_definition_tradetype = {
     init() {
@@ -30,6 +30,8 @@ window.Blockly.Blocks.trade_definition_tradetype = {
         this.setDeletable(false);
     },
     customContextMenu(menu) {
+        const menu_items = [localize('Enable Block'), localize('Disable Block')];
+        excludeOptionFromContextMenu(menu, menu_items);
         modifyContextMenu(menu);
     },
     enforceLimitations: window.Blockly.Blocks.trade_definition_market.enforceLimitations,


### PR DESCRIPTION
This pull request includes multiple changes to the `trade_definition` files in the `bot-skeleton` directory. The primary aim is to enhance the context menu functionality by excluding specific options.
Added method to remove the disable option on the trade parameter child blocks.