### PR TITLE
fix: add version for trackjs

### DIFF
--- a/src/hooks/useTrackjs.ts
+++ b/src/hooks/useTrackjs.ts
@@ -17,7 +17,10 @@ const useTrackjs = () => {
                     enabled: isProduction,
                     token: TRACKJS_TOKEN!,
                     userId: loginid,
-                    version: (document.querySelector('meta[name=version]') as HTMLMetaElement)?.content ?? 'undefined',
+                    version:
+                        (document.querySelector('meta[name=version]') as HTMLMetaElement)?.content ??
+                        process?.env?.REF_NAME ??
+                        'undefined',
                 });
             }
         } catch (error) {


### PR DESCRIPTION
This pull request includes an update to the `useTrackjs` hook in the `src/hooks/useTrackjs.ts` file. The change modifies the `version` property to include an additional fallback value from the environment variables.

* [`src/hooks/useTrackjs.ts`](diffhunk://#diff-a3c338371e016a85f1439b68696461946c57ff2fa5003033e90d48390d3a4d04L20-R23): Updated the `version` property to use `process?.env?.REF_NAME` as an additional fallback if the meta tag is not found.