### PR TITLE
fix: add version for trackjs

### DIFF
--- a/src/hooks/useTrackjs.ts
+++ b/src/hooks/useTrackjs.ts
@@ -8,6 +8,8 @@ const { TRACKJS_TOKEN } = process.env;
  */
 const useTrackjs = () => {
     const isProduction = process.env.APP_ENV === 'production';
+    const trackjs_version = process.env.REF_NAME ?? 'undefined';
+
     const initTrackJS = (loginid: string) => {
         try {
             if (!TrackJS.isInstalled()) {
@@ -18,9 +20,7 @@ const useTrackjs = () => {
                     token: TRACKJS_TOKEN!,
                     userId: loginid,
                     version:
-                        (document.querySelector('meta[name=version]') as HTMLMetaElement)?.content ??
-                        process?.env?.REF_NAME ??
-                        'undefined',
+                        (document.querySelector('meta[name=version]') as HTMLMetaElement)?.content ?? trackjs_version,
                 });
             }
         } catch (error) {


### PR DESCRIPTION
This pull request includes changes to the `src/hooks/useTrackjs.ts` file to improve the handling of the TrackJS version. The most important changes include introducing a new variable for the TrackJS version and simplifying the version assignment in the `initTrackJS` function.

Improvements to TrackJS version handling:

* [`src/hooks/useTrackjs.ts`](diffhunk://#diff-a3c338371e016a85f1439b68696461946c57ff2fa5003033e90d48390d3a4d04R11-R12): Introduced a new variable `trackjs_version` to store the TrackJS version, defaulting to 'undefined' if `process.env.REF_NAME` is not available.
* [`src/hooks/useTrackjs.ts`](diffhunk://#diff-a3c338371e016a85f1439b68696461946c57ff2fa5003033e90d48390d3a4d04L21-R23): Simplified the version assignment in the `initTrackJS` function by using the newly introduced `trackjs_version` variable.