### PR TITLE
maryia/BOT-2627/Spike [App Separation]: TrackJS "restoreStateSnapshot is not a function"

### DIFF
--- a/src/external/bot-skeleton/scratch/dbot.js
+++ b/src/external/bot-skeleton/scratch/dbot.js
@@ -266,7 +266,9 @@ class DBot {
             this.is_bot_running = true;
 
             api_base.setIsRunning(true);
-            this.interpreter.run(code).catch(error => {
+            this.interpreter.run(code).then(() => {
+                console.log('Running interpreter...');
+            }).catch(error => {
                 globalObserver.emit('Error', error);
                 this.stopBot();
             });


### PR DESCRIPTION
Spike [App Separation]: TrackJS "restoreStateSnapshot is not a function"

The error occurs during the run() → revert() → restoreStateSnapshot() call sequence because the Interpreter object becomes uninitialized during execution. Here are the possible causes:
1) Problem with initialization after the error
2) Consequences of reinitialization
3) Failure in takeStateSnapshot or lack of validation

To prevent the error .restoreStateStateSnapshot is not a function and to ensure stable operation of the interpreter, the corrected code can be represented as follows:
1. Add presence checks for the .restoreStateSnapshot method
2. Initializing the default interpreter
3. Guarantee that the state is saved in takeStateSnapshot()
4. Protect against incorrect states in restoreStateSnapshot()
5. Check state before use in run()
6. Use safe reinitialization