### PR TITLE
chore: update default stake on trade parameter upon account switch

### DIFF
--- a/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
@@ -242,12 +242,14 @@ window.Blockly.Blocks.trade_definition_tradeoptions = {
         const { currency, landing_company_shortcode } = DBotStore.instance.client;
         if (isAuthorizing$.getValue()) return;
         account_limits.getStakePayoutLimits(currency, landing_company_shortcode, this.selected_market).then(limits => {
-            if (!this.getField('AMOUNT_LIMITS')) {
-                return;
-            }
+            const unsupported_trade_types = ['multiplier', 'accumulator'];
+            if (unsupported_trade_types.includes(this.selected_trade_type)) return;
+            const currency_block = this.getField('CURRENCY_LIST')?.getSourceBlock();
+            const currency_child_block = currency_block?.getChildren()?.[1]?.getField('NUM');
+            if (!this.getField('AMOUNT_LIMITS') && !currency_block && !currency_child_block) return;
             this.amount_limits = limits;
             const { max_payout, min_stake } = limits;
-            if (max_payout && min_stake && this.selected_trade_type !== 'multiplier') {
+            if (max_payout && min_stake) {
                 runIrreversibleEvents(() => {
                     this.setFieldValue(
                         localize('(min: {{min_stake}} - max: {{max_payout}})', {
@@ -257,6 +259,9 @@ window.Blockly.Blocks.trade_definition_tradeoptions = {
                         'AMOUNT_LIMITS'
                     );
                 });
+                if (currency_block && currency_child_block) {
+                    currency_child_block.setValue(this.amount_limits?.min_stake);
+                }
             }
         });
     },


### PR DESCRIPTION
This pull request includes changes to the `trade_definition_tradeoptions` block in the `src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js` file. The changes add checks for unsupported trade types and ensure that the minimum stake value is set correctly for certain currency blocks.

Key changes:

* Added a check to exclude unsupported trade types 'multiplier' and 'accumulator' from processing.
* Introduced additional checks to ensure that `currency_block` and `currency_child_block` exist before proceeding.
* Set the value of `currency_child_block` to the minimum stake when both `currency_block` and `currency_child_block` are present.