### PR TITLE
maryia/BOT-2662/Fix: "Total Events Triggered per Strategy - Run or Edit" table on lookerstudio.google.com dashboard might not be reflecting the right data for quick strategy usage

### DIFF
--- a/src/analytics/utils.ts
+++ b/src/analytics/utils.ts
@@ -15,7 +15,7 @@ export const getRsDropdownTextFromLocalStorage = () => {
 
 const hasStoredText = (parameter: string) => parameter && parameter !== STORED_ITEM_NOT_FOUND;
 
-export const getRsStrategyType = (selected_strategy: string) => STRATEGIES[selected_strategy]?.rs_strategy_name;
+export const getRsStrategyType = (selected_strategy: string) => STRATEGIES()[selected_strategy]?.rs_strategy_name;
 
 export const getQsActiveTabString = (tab: string) => (tab === 'TRADE_PARAMETERS' ? 'trade parameters' : 'learn more');
 

--- a/src/pages/bot-builder/quick-strategy/config.ts
+++ b/src/pages/bot-builder/quick-strategy/config.ts
@@ -449,7 +449,7 @@ export const STRATEGIES = (): TStrategies => ({
     ACCUMULATORS_MARTINGALE: {
         name: 'accumulators_martingale',
         label: localize('Martingale'),
-        rs_strategy_name: `ACCUMULATORS_MARTINGALE`,
+        rs_strategy_name: 'accumulators_martingale',
         description: [],
         fields: [
             [LABEL_SYMBOL(), SYMBOL(), LABEL_STAKE(), STAKE(), GROWTH_RATE(), GROWTH_RATE_VALUE()],
@@ -472,7 +472,7 @@ export const STRATEGIES = (): TStrategies => ({
     ACCUMULATORS_DALEMBERT: {
         name: 'accumulators_dalembert',
         label: localize('D’Alembert'),
-        rs_strategy_name: `ACCUMULATORS_DALEMBERT`,
+        rs_strategy_name: 'accumulators_dalembert',
         description: [],
         fields: [
             [LABEL_SYMBOL(), SYMBOL(), LABEL_STAKE(), STAKE(), GROWTH_RATE(), GROWTH_RATE_VALUE()],
@@ -495,7 +495,7 @@ export const STRATEGIES = (): TStrategies => ({
     ACCUMULATORS_MARTINGALE_ON_STAT_RESET: {
         name: 'accumulators_martingale_on_stat_reset',
         label: localize('Martingale on Stat Reset'),
-        rs_strategy_name: `ACCUMULATORS_MARTINGALE_ON_STAT_RESET`,
+        rs_strategy_name: 'accumulators_martingale_on_stat_reset',
         description: [],
         fields: [
             [LABEL_SYMBOL(), SYMBOL(), LABEL_STAKE(), STAKE(), GROWTH_RATE(), GROWTH_RATE_VALUE()],
@@ -518,7 +518,7 @@ export const STRATEGIES = (): TStrategies => ({
     ACCUMULATORS_DALEMBERT_ON_STAT_RESET: {
         name: 'accumulators_dalembert_on_stat_reset',
         label: localize("D'Alembert on Stat Reset"),
-        rs_strategy_name: `ACCUMULATORS_DALEMBERT_ON_STAT_RESET`,
+        rs_strategy_name: 'accumulators_dalembert_on_stat_reset',
         description: [],
         fields: [
             [LABEL_SYMBOL(), SYMBOL(), LABEL_STAKE(), STAKE(), GROWTH_RATE(), GROWTH_RATE_VALUE()],
@@ -541,7 +541,7 @@ export const STRATEGIES = (): TStrategies => ({
     ACCUMULATORS_REVERSE_MARTINGALE: {
         name: 'accumulators_reverse_martingale',
         label: localize('Reverse Martingale'),
-        rs_strategy_name: `ACCUMULATORS_REVERSE_MARTINGALE`,
+        rs_strategy_name: 'accumulators_reverse_martingale',
         description: [],
         fields: [
             [LABEL_SYMBOL(), SYMBOL(), LABEL_STAKE(), STAKE(), GROWTH_RATE(), GROWTH_RATE_VALUE()],
@@ -564,7 +564,7 @@ export const STRATEGIES = (): TStrategies => ({
     ACCUMULATORS_REVERSE_MARTINGALE_ON_STAT_RESET: {
         name: 'accumulators_reverse_martingale_on_stat_reset',
         label: localize('Reverse Martingale on Stat Reset'),
-        rs_strategy_name: `ACCUMULATORS_REVERSE_MARTINGALE_ON_STAT_RESET`,
+        rs_strategy_name: 'accumulators_reverse_martingale_on_stat_reset',
         description: [],
         fields: [
             [LABEL_SYMBOL(), SYMBOL(), LABEL_STAKE(), STAKE(), GROWTH_RATE(), GROWTH_RATE_VALUE()],
@@ -587,7 +587,7 @@ export const STRATEGIES = (): TStrategies => ({
     ACCUMULATORS_REVERSE_DALEMBERT: {
         name: 'accumulators_reverse_dalembert',
         label: localize("Reverse D'Alembert"),
-        rs_strategy_name: `ACCUMULATORS_REVERSE_DALEMBERT`,
+        rs_strategy_name: 'accumulators_reverse_dalembert',
         description: [],
         fields: [
             [LABEL_SYMBOL(), SYMBOL(), LABEL_STAKE(), STAKE(), GROWTH_RATE(), GROWTH_RATE_VALUE()],
@@ -610,7 +610,7 @@ export const STRATEGIES = (): TStrategies => ({
     ACCUMULATORS_REVERSE_DALEMBERT_ON_STAT_RESET: {
         name: 'accumulators_reverse_dalembert_on_stat_reset',
         label: localize("Reverse D'Alembert on Stat Reset"),
-        rs_strategy_name: `ACCUMULATORS_REVERSE_DALEMBERT_ON_STAT_RESET`,
+        rs_strategy_name: 'accumulators_reverse_dalembert_on_stat_reset',
         description: [],
         fields: [
             [LABEL_SYMBOL(), SYMBOL(), LABEL_STAKE(), STAKE(), GROWTH_RATE(), GROWTH_RATE_VALUE()],

--- a/src/pages/bot-builder/quick-strategy/types.ts
+++ b/src/pages/bot-builder/quick-strategy/types.ts
@@ -120,14 +120,14 @@ export type TRsStrategyName =
     | `reverse martingale`
     | `reverse d'alembert`
     | `1-3-2-6`
-    | `ACCUMULATORS_MARTINGALE`
-    | `ACCUMULATORS_DALEMBERT`
-    | `ACCUMULATORS_MARTINGALE_ON_STAT_RESET`
-    | `ACCUMULATORS_DALEMBERT_ON_STAT_RESET`
-    | `ACCUMULATORS_REVERSE_MARTINGALE`
-    | `ACCUMULATORS_REVERSE_MARTINGALE_ON_STAT_RESET`
-    | `ACCUMULATORS_REVERSE_DALEMBERT`
-    | `ACCUMULATORS_REVERSE_DALEMBERT_ON_STAT_RESET`;
+    | `accumulators_martingale`
+    | `accumulators_dalembert`
+    | `accumulators_martingale_on_stat_reset`
+    | `accumulators_dalembert_on_stat_reset`
+    | `accumulators_reverse_martingale`
+    | `accumulators_reverse_martingale_on_stat_reset`
+    | `accumulators_reverse_dalembert`
+    | `accumulators_reverse_dalembert_on_stat_reset`;
 
 export type TDurationType = 't' | 's' | 'm' | 'h' | 'd';
 


### PR DESCRIPTION
Fix: "Total Events Triggered per Strategy - Run or Edit" table on lookerstudio.google.com dashboard might not be reflecting the right data for quick strategy usage
<img width="1095" alt="Screenshot 2024-12-31 at 12 48 06" src="https://github.com/user-attachments/assets/07603f75-0700-4c0f-8754-74a1c1058f6b" />
