### PR TITLE
fix vercel dr publish

### DIFF
--- a/vercel.dr.json
+++ b/vercel.dr.json
@@ -1,5 +1,10 @@
 {
-    "cleanUrls": true,
     "outputDirectory": "dist",
-    "buildCommand": "echo ✅  Skipping build to use existing built files"
+    "buildCommand": "echo ✅  Skipping build to use existing built files",
+    "rewrites": [
+        {
+            "source": "/(.*)",
+            "destination": "/index.html"
+        }
+    ]
 }


### PR DESCRIPTION
Fixed vercel.json for SPA routing configuration

## Description
Added `vercel.json` to handle client-side routing in our Single Page Application (SPA) when deployed to Vercel. This configuration ensures that all routes are properly handled and prevents 404 errors when accessing paths directly or refreshing pages.

## Changes

- Modified vercel.dr.json to include both build settings and SPA routing configuration
- Used rewrites instead of routes for better compatibility
- Removed cleanUrls as it was causing 404 errors on subpages when combined with rewrites
