### PR TITLE
maryia/BOT-2661/[App Separation] - Integrate query param logic to maintain auth context propagation

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -59,9 +59,9 @@ function App() {
                 if (!defaultActiveAccount) return;
 
                 const accountsList: Record<string, string> = {};
-                const clientAccounts: Record<string, { loginid: string; token: string }> = {};
+                const clientAccounts: Record<string, { loginid: string; token: string; currency: string }> = {};
 
-                loginInfo.forEach((account: { loginid: string; token: string }) => {
+                loginInfo.forEach((account: { loginid: string; token: string; currency: string }) => {
                     accountsList[account.loginid] = account.token;
                     clientAccounts[account.loginid] = account;
                 });

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -98,14 +98,12 @@ function App() {
         const active_loginid = localStorage.getItem('active_loginid');
         const url_params = new URLSearchParams(window.location.search);
         const account_currency = url_params.get('account');
-        console.log('client_accounts', client_accounts);
 
         if (!account_currency || !accounts_list || !client_accounts) return;
 
         try {
             const parsed_accounts = JSON.parse(accounts_list);
             const parsed_client_accounts = JSON.parse(client_accounts) as TAuthData['account_list'];
-            console.log('parsed_client_accounts', parsed_client_accounts);
 
             const is_valid_currency = config().lists.CURRENCY.includes(account_currency);
 
@@ -130,7 +128,6 @@ function App() {
                 const real_account = Object.entries(parsed_client_accounts).find(
                     ([loginid, account]) => !loginid.startsWith('VR') && account.currency === account_currency
                 );
-                console.log('real_account', real_account);
 
                 if (real_account) {
                     const [loginid, account] = real_account;

--- a/src/components/layout/header/account-switcher.tsx
+++ b/src/components/layout/header/account-switcher.tsx
@@ -139,6 +139,12 @@ const AccountSwitcher = observer(({ activeAccount }: TAccountSwitcher) => {
         localStorage.setItem('authToken', token);
         localStorage.setItem('active_loginid', loginId.toString());
         await api_base?.init(true);
+        const search_params = new URLSearchParams(window.location.search);
+        const selected_account = modifiedAccountList.find(acc => acc.loginid === loginId.toString());
+        if (!selected_account) return;
+        const account_param = selected_account.is_virtual ? 'demo' : selected_account.currency || 'USD';
+        search_params.set('account', account_param);
+        window.history.pushState({}, '', `${window.location.pathname}?${search_params.toString()}`);
     };
 
     return (

--- a/src/components/layout/header/account-switcher.tsx
+++ b/src/components/layout/header/account-switcher.tsx
@@ -139,12 +139,12 @@ const AccountSwitcher = observer(({ activeAccount }: TAccountSwitcher) => {
         localStorage.setItem('authToken', token);
         localStorage.setItem('active_loginid', loginId.toString());
         await api_base?.init(true);
-        const url_params = new URLSearchParams(window.location.search);
-        const account_currency = url_params.get('account');
-        if (account_currency) {
-            url_params.delete('account');
-            window.history.pushState({}, '', `${window.location.pathname}?${url_params.toString()}`);
-        }
+        const search_params = new URLSearchParams(window.location.search);
+        const selected_account = modifiedAccountList.find(acc => acc.loginid === loginId.toString());
+        if (!selected_account) return;
+        const account_param = selected_account.is_virtual ? 'demo' : selected_account.currency || 'USD';
+        search_params.set('account', account_param);
+        window.history.pushState({}, '', `${window.location.pathname}?${search_params.toString()}`);
     };
 
     return (

--- a/src/components/layout/header/account-switcher.tsx
+++ b/src/components/layout/header/account-switcher.tsx
@@ -142,7 +142,7 @@ const AccountSwitcher = observer(({ activeAccount }: TAccountSwitcher) => {
         const search_params = new URLSearchParams(window.location.search);
         const selected_account = modifiedAccountList.find(acc => acc.loginid === loginId.toString());
         if (!selected_account) return;
-        const account_param = selected_account.is_virtual ? 'demo' : selected_account.currency || 'USD';
+        const account_param = selected_account.is_virtual ? 'demo' : selected_account.currency;
         search_params.set('account', account_param);
         window.history.pushState({}, '', `${window.location.pathname}?${search_params.toString()}`);
     };

--- a/src/components/layout/header/account-switcher.tsx
+++ b/src/components/layout/header/account-switcher.tsx
@@ -139,12 +139,12 @@ const AccountSwitcher = observer(({ activeAccount }: TAccountSwitcher) => {
         localStorage.setItem('authToken', token);
         localStorage.setItem('active_loginid', loginId.toString());
         await api_base?.init(true);
-        const search_params = new URLSearchParams(window.location.search);
-        const selected_account = modifiedAccountList.find(acc => acc.loginid === loginId.toString());
-        if (!selected_account) return;
-        const account_param = selected_account.is_virtual ? 'demo' : selected_account.currency || 'USD';
-        search_params.set('account', account_param);
-        window.history.pushState({}, '', `${window.location.pathname}?${search_params.toString()}`);
+        const url_params = new URLSearchParams(window.location.search);
+        const account_currency = url_params.get('account');
+        if (account_currency) {
+            url_params.delete('account');
+            window.history.pushState({}, '', `${window.location.pathname}?${url_params.toString()}`);
+        }
     };
 
     return (

--- a/src/components/layout/header/platform-switcher/platform-switcher.tsx
+++ b/src/components/layout/header/platform-switcher/platform-switcher.tsx
@@ -22,7 +22,7 @@ const PlatformSwitcher = () => {
                     active={active}
                     className='platform-switcher'
                     description={localize('{{description}}', { description })}
-                    href={href}
+                    href={window.location.search ? `${href}/${window.location.search}` : href}
                     icon={icon}
                     key={description}
                 />


### PR DESCRIPTION
[App Separation] - Integrate query param logic to maintain auth context propagation

Description: As a developer I want to implement a seamless auth flow. Meaning if the user clicks on DBot from [app.deriv.com](http://app.deriv.com/) (Traders Hub/Dtrader) or any other app. It should propagate the selected account in the source tab to the newly opened tab.

Slack Conversation: https://deriv-group.slack.com/archives/C0871BRSJN4/p1735032395607869 

Scenarios Document: https://docs.google.com/document/d/1Taq5ypnVG8KDVWTx5IdPJyWRaB3PCaNXa2yEVOMddNA/edit?usp=sharing 

<img width="623" alt="Screenshot 2025-01-03 at 17 16 44" src="https://github.com/user-attachments/assets/90410bfd-4ece-4127-8e99-c076ac8eddba" />

[DBOT] Account Switching Across Tabs

We need to standardise the behaviour of the platforms/tabs being opened from the TH and vice versa. Due to different standalone applications - Bots, P2P, Dtrader and TH the behaviour varies across different apps and clicks.
There are 3 ground rules to be taken care of :
No Back-syncing
Example : If an app, say DTrader, is opened with Demo account selected and user clicks on TH in a new tab and switches it to Real USD , then the previously opened DTrader will NOT be updated to Real USD.
2. Use the Source currency
Example : User is working on DTrader in demo account and then opens TH in new tab and switches it to Real USD. After this he opens Bots. Bots account should then be opened for Real USD.
3. Start a new tab/browser
 If a user opens a new tab/browser and types in the URL (rather than opening it from the previously opened tab), then it should check the last opened state of the platform in the browser.  If no previous state is found, it should be defaulted to Real FIAT account or Demo (if real is not created).
Example : If an app, say DTrader, is opened with Demo account selected and user clicks on TH in a new tab and switches it to Real USD. Then he opens a new tab and types in Bots URL. If he had previously accessed Bots with ETH currency, then the same should be opened now too.