### PR TITLE
chore: remove clientAccounts on logout

### DIFF
--- a/src/stores/client-store.ts
+++ b/src/stores/client-store.ts
@@ -308,6 +308,7 @@ export default class ClientStore {
         localStorage.removeItem('active_loginid');
         localStorage.removeItem('accountsList');
         localStorage.removeItem('authToken');
+        localStorage.removeItem('clientAccounts');
 
         setIsAuthorized(false);
         setAccountList([]);


### PR DESCRIPTION
This pull request includes a small change to the `ClientStore` class in the `src/stores/client-store.ts` file. The change ensures that the `clientAccounts` item is also removed from local storage when clearing user data.

* [`src/stores/client-store.ts`](diffhunk://#diff-9871fceff588cf0886088bfb95115a7c98e9dda049ebdd6f58ccb86836019e89R311): Added removal of `clientAccounts` from local storage in the `ClientStore` class.