### PR TITLE
fix: active symbol call sequence after authorize

### DIFF
--- a/src/external/bot-skeleton/services/api/api-base.ts
+++ b/src/external/bot-skeleton/services/api/api-base.ts
@@ -100,7 +100,7 @@ class APIBase {
             this.api?.connection.addEventListener('close', this.onsocketclose.bind(this));
         }
 
-        if (!this.has_active_symbols) {
+        if (!this.has_active_symbols && !V2GetActiveToken()) {
             this.active_symbols_promise = this.getActiveSymbols();
         }
 


### PR DESCRIPTION
This pull request includes a small but important change to the `src/external/bot-skeleton/services/api/api-base.ts` file. The change adds a condition to check for an active token before setting the `active_symbols_promise`.

* [`src/external/bot-skeleton/services/api/api-base.ts`](diffhunk://#diff-3b0931891357dd6358fa53dcd1ab528d4de6ec5e344c41956adbe694df9e4c89L103-R103): Modified the condition to check for an active token using `V2GetActiveToken()` before setting `active_symbols_promise`.