### PR TITLE
Rupato/Fix Blockly mandatory block error

### DIFF
--- a/src/external/bot-skeleton/scratch/utils/index.js
+++ b/src/external/bot-skeleton/scratch/utils/index.js
@@ -406,14 +406,14 @@ const getMissingBlocks = (workspace, required_block_types) => {
 const getDisabledBlocks = required_blocks_check => {
     const workspace = window.Blockly.derivWorkspace;
     const required_block_types = [getSelectedTradeType(workspace), ...config().mandatoryMainBlocks];
-    const flag_disabled_blocks = Object.fromEntries(
+    const disabled_blocks = Object.fromEntries(
         workspace
             .getAllBlocks()
             .filter(block => required_block_types.includes(block.type))
             .map(block => [block.type, block.disabled])
     );
     const mandatory_blocks = ['before_purchase', 'purchase', 'trade_definition', 'trade_definition_tradeoptions'];
-    const has_disabled_blocks = mandatory_blocks.some(type => flag_disabled_blocks[type]);
+    const has_disabled_blocks = mandatory_blocks.some(type => disabled_blocks[type]);
 
     return has_disabled_blocks
         ? required_blocks_check.filter(block => block.disabled || block.childBlocks_?.some(child => child.disabled))

--- a/src/external/bot-skeleton/scratch/utils/index.js
+++ b/src/external/bot-skeleton/scratch/utils/index.js
@@ -412,7 +412,6 @@ const getDisabledBlocks = required_blocks_check => {
             .filter(block => required_block_types.includes(block.type))
             .map(block => [block.type, block.disabled])
     );
-
     const mandatory_blocks = ['before_purchase', 'purchase', 'trade_definition', 'trade_definition_tradeoptions'];
     const has_disabled_blocks = mandatory_blocks.some(type => flag_disabled_blocks[type]);
 

--- a/src/external/bot-skeleton/scratch/utils/index.js
+++ b/src/external/bot-skeleton/scratch/utils/index.js
@@ -404,11 +404,21 @@ const getMissingBlocks = (workspace, required_block_types) => {
 };
 
 const getDisabledBlocks = required_blocks_check => {
-    return required_blocks_check.filter(block => {
-        const hasDisabledChild =
-            block.childBlocks_ && block.childBlocks_.some(childBlock => childBlock.disabled === true);
-        return block.disabled === true || hasDisabledChild;
-    });
+    const workspace = window.Blockly.derivWorkspace;
+    const required_block_types = [getSelectedTradeType(workspace), ...config().mandatoryMainBlocks];
+    const flag_disabled_blocks = Object.fromEntries(
+        workspace
+            .getAllBlocks()
+            .filter(block => required_block_types.includes(block.type))
+            .map(block => [block.type, block.disabled])
+    );
+
+    const mandatory_blocks = ['before_purchase', 'purchase', 'trade_definition', 'trade_definition_tradeoptions'];
+    const has_disabled_blocks = mandatory_blocks.some(type => flag_disabled_blocks[type]);
+
+    return has_disabled_blocks
+        ? required_blocks_check.filter(block => block.disabled || block.childBlocks_?.some(child => child.disabled))
+        : [];
 };
 
 const throwNewErrorMessage = (error_blocks, key) => {


### PR DESCRIPTION
This pull request includes significant changes to the `getDisabledBlocks` function in the `src/external/bot-skeleton/scratch/utils/index.js` file. The changes enhance the logic for identifying disabled blocks by incorporating a list of required block types and checking for mandatory blocks.

Key changes include:

* [`src/external/bot-skeleton/scratch/utils/index.js`](diffhunk://#diff-02a1baf8cbe6106e718d189be9fd8018e21b9ff729131f27aedfa85724803c04L407-R421): Refactored the `getDisabledBlocks` function to use the `workspace` and `required_block_types` parameters to identify and flag disabled blocks. This includes checking for mandatory blocks and filtering based on their disabled status.