### PR TITLE
Rupato/BOT-2690/Fix for the survicate script

### DIFF
--- a/src/components/error-component/error-boundary.js
+++ b/src/components/error-component/error-boundary.js
@@ -9,6 +9,11 @@ class ErrorBoundary extends React.Component {
     }
 
     componentDidCatch = (error, info) => {
+        if (error?.message?.includes('survicate.com')) {
+            console.warn('Survicate script error:', error.message);
+            return;
+        }
+
         if (window.TrackJS) window.TrackJS.console.log(this.props.root_store);
 
         this.setState({

--- a/src/public-path.ts
+++ b/src/public-path.ts
@@ -20,6 +20,7 @@ declare global {
         Survicate?: {
             track: (attribute: string, value: string) => void;
         };
+        TrackJS: { configure: (config: { onError: (payload: any) => boolean }) => void };
     }
 }
 
@@ -37,11 +38,16 @@ const setSurvicateCalledValue = (value: boolean) => {
 };
 
 const loadSurvicateScript = (callback: () => void) => {
+    if (document.getElementById('dbot-survicate')) return;
+
     const script = document.createElement('script');
     script.id = 'dbot-survicate';
     script.async = true;
     script.src = 'https://survey.survicate.com/workspaces/83b651f6b3eca1ab4551d95760fe5deb/web_surveys.js';
     script.onload = callback;
+    script.onerror = () => {
+        console.warn('Survicate script failed to load, ignoring error.');
+    };
 
     const firstScript = document.getElementsByTagName('script')[0];
     if (firstScript?.parentNode) {


### PR DESCRIPTION
This pull request includes updates to error handling and script loading for the Survicate service in the `src/components/error-component/error-boundary.js` and `src/public-path.ts` files. The primary changes involve adding specific error handling for Survicate script errors and ensuring the Survicate script is only loaded once.

Error handling improvements:

* [`src/components/error-component/error-boundary.js`](diffhunk://#diff-ab49eda92a0cfc362c425a902221e0758462f898859d2bb3fe59c098070e1535R12-R16): Added a check to handle errors related to the Survicate script specifically, logging a warning message and preventing further error handling for these cases.

Script loading enhancements:

* [`src/public-path.ts`](diffhunk://#diff-480b1c69fc01d00b0bc2e40f333fa2bbb13f6e9612b5dba6966f67d542fe215aR23): Added a property to the global declaration for the TrackJS configuration.
* [`src/public-path.ts`](diffhunk://#diff-480b1c69fc01d00b0bc2e40f333fa2bbb13f6e9612b5dba6966f67d542fe215aR41-R50): Modified the `loadSurvicateScript` function to check if the Survicate script is already loaded before attempting to load it again, and added an error handler to log a warning if the script fails to load.