### PR TITLE
fix: silent login

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -59,14 +59,14 @@ function App() {
         };
     }, []);
 
-    // const updateAccountParamInURL = (account_data: TAuthData['account_list'][number], fallback_currency = '') => {
-    //     const search_params = new URLSearchParams(window.location.search);
-    //     const account_param = account_data.loginid.startsWith('VR')
-    //         ? 'demo'
-    //         : account_data.currency || fallback_currency;
-    //     search_params.set('account', account_param);
-    //     //window.history.pushState({}, '', `${window.location.pathname}?${search_params.toString()}`);
-    // };
+    const updateAccountParamInURL = (account_data: TAuthData['account_list'][number], fallback_currency = '') => {
+        const search_params = new URLSearchParams(window.location.search);
+        const account_param = account_data.loginid.startsWith('VR')
+            ? 'demo'
+            : account_data.currency || fallback_currency;
+        search_params.set('account', account_param);
+        window.history.pushState({}, '', `${window.location.pathname}?${search_params.toString()}`);
+    };
 
     React.useEffect(() => {
         const accounts_list = localStorage.getItem('accountsList');
@@ -85,7 +85,7 @@ function App() {
                 );
                 if (!selected_account) return;
                 const [/* eslint-disable-line @typescript-eslint/no-unused-vars */ _, account] = selected_account;
-                //updateAccountParamInURL(account);
+                updateAccountParamInURL(account);
             } catch (e) {
                 console.warn('Error', e); // eslint-disable-line no-console
             }
@@ -142,7 +142,7 @@ function App() {
                 );
                 if (!selected_account) return;
                 const [_, account] = selected_account; // eslint-disable-line @typescript-eslint/no-unused-vars
-                //updateAccountParamInURL(account, 'USD');
+                updateAccountParamInURL(account, 'USD');
             }
         } catch (e) {
             console.warn('Error', e); // eslint-disable-line no-console

--- a/src/components/shared/utils/currency/currency.ts
+++ b/src/components/shared/utils/currency/currency.ts
@@ -24,8 +24,8 @@ export type TCurrenciesConfig = {
 
 let currencies_config: TCurrenciesConfig = {};
 
-const fiat_currencies_display_order = ['USD', 'EUR', 'GBP', 'AUD'];
-const crypto_currencies_display_order = [
+export const fiat_currencies_display_order = ['USD', 'EUR', 'GBP', 'AUD'];
+export const crypto_currencies_display_order = [
     'TUSDT',
     'BTC',
     'ETH',


### PR DESCRIPTION
This pull request includes several changes to the `src/app/App.tsx` and `src/components/layout/index.tsx` files, as well as an update to the currency configuration in `src/components/shared/utils/currency/currency.ts`. The primary focus of these changes is to re-enable and update the `updateAccountParamInURL` function, manage client account states, and export currency display orders.

### Key Changes:

#### Re-enabling and Updating Functions:
* [`src/app/App.tsx`](diffhunk://#diff-7c79023b16fd616788af0fdcb31d619ae04da7259aa564fd72fb0ea07d8ebe07L62-R69): Re-enabled and updated the `updateAccountParamInURL` function to set the account parameter in the URL and push the updated state to the browser history. [[1]](diffhunk://#diff-7c79023b16fd616788af0fdcb31d619ae04da7259aa564fd72fb0ea07d8ebe07L62-R69) [[2]](diffhunk://#diff-7c79023b16fd616788af0fdcb31d619ae04da7259aa564fd72fb0ea07d8ebe07L88-R88) [[3]](diffhunk://#diff-7c79023b16fd616788af0fdcb31d619ae04da7259aa564fd72fb0ea07d8ebe07L145-R145)

#### Managing Client Account States:
* [`src/components/layout/index.tsx`](diffhunk://#diff-297411bbdb20a2ca96207a6e5284cd0598f90d22b776fa55232a04fae431835aL1-R9): Introduced state management for client accounts by adding `useState` for `clientHasCurrency` and validating API accounts to ensure the correct account currency is set. [[1]](diffhunk://#diff-297411bbdb20a2ca96207a6e5284cd0598f90d22b776fa55232a04fae431835aL1-R9) [[2]](diffhunk://#diff-297411bbdb20a2ca96207a6e5284cd0598f90d22b776fa55232a04fae431835aL24-R68) [[3]](diffhunk://#diff-297411bbdb20a2ca96207a6e5284cd0598f90d22b776fa55232a04fae431835aL54-R81)

#### Exporting Currency Display Orders:
* [`src/components/shared/utils/currency/currency.ts`](diffhunk://#diff-4691a31970042b8bbf1c9d88571e07d96e8c30f031b84c6efb32e49f051c2a45L27-R28): Exported `fiat_currencies_display_order` and `crypto_currencies_display_order` to be used across the application.