### PR TITLE
Rupato/fix  OIDC  query param

### DIFF
--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -44,7 +44,7 @@ const Layout = () => {
 
             const hasMissingCurrency = api_accounts?.flat().some(data => {
                 if (!allCurrencies.has(data.currency)) {
-                    localStorage.setItem('missing_currency', data.currency);
+                    sessionStorage.setItem('missing_currency', currency);
                     return true;
                 }
                 return false;

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -53,7 +53,7 @@ const Layout = () => {
             if (hasMissingCurrency) {
                 setClientHasCurrency(false);
             } else {
-                localStorage.removeItem('missing_currency');
+                sessionStorage.removeItem('missing_currency');
                 console.log('All currencies are present');
             }
 

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -44,7 +44,7 @@ const Layout = () => {
 
             const hasMissingCurrency = api_accounts?.flat().some(data => {
                 if (!allCurrencies.has(data.currency)) {
-                    sessionStorage.setItem('missing_currency', currency);
+                    sessionStorage.setItem('query_param_currency', currency);
                     return true;
                 }
                 return false;
@@ -53,7 +53,7 @@ const Layout = () => {
             if (hasMissingCurrency) {
                 setClientHasCurrency(false);
             } else {
-                sessionStorage.removeItem('missing_currency');
+                sessionStorage.removeItem('query_param_currency');
                 console.log('All currencies are present');
             }
 

--- a/src/pages/callback/callback-page.tsx
+++ b/src/pages/callback/callback-page.tsx
@@ -53,8 +53,8 @@ const CallbackPage = () => {
                     localStorage.setItem('active_loginid', tokens.acct1);
                 }
 
-                const missing_currency = sessionStorage.getItem('missing_currency');
-                window.location.assign(missing_currency ? `/?account=${missing_currency}` : '/');
+                const query_param_currency = sessionStorage.getItem('currency');
+                window.location.assign(query_param_currency ? `/?account=${query_param_currency}` : '/');
             }}
             renderReturnButton={() => {
                 return (

--- a/src/pages/callback/callback-page.tsx
+++ b/src/pages/callback/callback-page.tsx
@@ -53,7 +53,7 @@ const CallbackPage = () => {
                     localStorage.setItem('active_loginid', tokens.acct1);
                 }
 
-                const missing_currency = localStorage.getItem('missing_currency');
+                const missing_currency = sessionStorage.getItem('missing_currency');
                 window.location.assign(missing_currency ? `/?account=${missing_currency}` : '/');
             }}
             renderReturnButton={() => {


### PR DESCRIPTION
This pull request focuses on changing the storage mechanism for currency-related data from `localStorage` to `sessionStorage` in the `src/components/layout/index.tsx` and `src/pages/callback/callback-page.tsx` files. The key changes include updating how currency data is stored and retrieved, ensuring that the session-specific data is used instead of data that persists across sessions.

Changes to storage mechanism:

* [`src/components/layout/index.tsx`](diffhunk://#diff-297411bbdb20a2ca96207a6e5284cd0598f90d22b776fa55232a04fae431835aL47-R47): Replaced `localStorage` with `sessionStorage` for setting and removing the `query_param_currency`. [[1]](diffhunk://#diff-297411bbdb20a2ca96207a6e5284cd0598f90d22b776fa55232a04fae431835aL47-R47) [[2]](diffhunk://#diff-297411bbdb20a2ca96207a6e5284cd0598f90d22b776fa55232a04fae431835aL56-R56)
* [`src/pages/callback/callback-page.tsx`](diffhunk://#diff-48442a2313eb74f85495b7177c68f5054c9518faf6198893217e053cb9a7b836L56-R57): Updated the retrieval of the currency data from `localStorage` to `sessionStorage` and adjusted the redirection logic accordingly.