### PR TITLE
fix: cloudflare workdlow

### DIFF
--- a/.github/workflows/build-and-deploy-production.yml
+++ b/.github/workflows/build-and-deploy-production.yml
@@ -26,7 +26,7 @@ jobs:
 
             - name: Get cached dependencies
               id: cache-npm
-              uses: actions/cache/restore@e12d46a63a90f2fae62d114769bbf2a179198b5c
+              uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf
               with:
                   path: node_modules
                   key: npm-${{ hashFiles('./package-lock.json') }}

--- a/.github/workflows/build-and-deploy-staging.yml
+++ b/.github/workflows/build-and-deploy-staging.yml
@@ -26,7 +26,7 @@ jobs:
 
             - name: Get cached dependencies
               id: cache-npm
-              uses: actions/cache/restore@e12d46a63a90f2fae62d114769bbf2a179198b5c
+              uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf
               with:
                   path: node_modules
                   key: npm-${{ hashFiles('./package-lock.json') }}

--- a/.github/workflows/build-and-deploy-test.yml
+++ b/.github/workflows/build-and-deploy-test.yml
@@ -65,7 +65,7 @@ jobs:
 
             - name: Get cached dependencies
               id: cache-npm
-              uses: actions/cache/restore@e12d46a63a90f2fae62d114769bbf2a179198b5c
+              uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf
               with:
                   path: node_modules
                   key: npm-${{ hashFiles('./package-lock.json') }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use a newer version of the `actions/cache` action for caching npm dependencies. The updates are applied across the production, staging, and test workflows.

Changes to GitHub Actions workflows:

* [`.github/workflows/build-and-deploy-production.yml`](diffhunk://#diff-d8dfcbc7adf0e8cc7010e2eb020a5be671e7fed87aa32446ae7ef0e66fc1bfcaL29-R29): Updated the `actions/cache` action to version `d4323d4df104b026a6aa633fdb11d772146be0bf` for caching npm dependencies.
* [`.github/workflows/build-and-deploy-staging.yml`](diffhunk://#diff-b709f2739a5258d6c2c45e190ddc8e9329c2492822f44b593a8de5145e930b42L29-R29): Updated the `actions/cache` action to version `d4323d4df104b026a6aa633fdb11d772146be0bf` for caching npm dependencies.
* [`.github/workflows/build-and-deploy-test.yml`](diffhunk://#diff-d63278f79551d70a0ecc23a55e3dc2e84fbd33ca883e2eed36768ae27c245fa5L68-R68): Updated the `actions/cache` action to version `d4323d4df104b026a6aa633fdb11d772146be0bf` for caching npm dependencies.