### PR TITLE
fix: updated sha

### DIFF
--- a/.github/workflows/build-and-deploy-test.yml
+++ b/.github/workflows/build-and-deploy-test.yml
@@ -65,7 +65,7 @@ jobs:
 
             - name: Get cached dependencies
               id: cache-npm
-              uses: actions/cache/restore@e12d46a63a90f2fae62d114769bbf2a179198b5c
+              uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf
               with:
                   path: node_modules
                   key: npm-${{ hashFiles('./package-lock.json') }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build-and-deploy-test.yml` file. The change updates the `actions/cache/restore` action to a new version.

* [`.github/workflows/build-and-deploy-test.yml`](diffhunk://#diff-d63278f79551d70a0ecc23a55e3dc2e84fbd33ca883e2eed36768ae27c245fa5L68-R68): Updated `actions/cache/restore` action from `e12d46a63a90f2fae62d114769bbf2a179198b5c` to `d4323d4df104b026a6aa633fdb11d772146be0bf`.