### PR TITLE
fix: added optionalDependencies for rspack

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,5 +152,8 @@
         "webpack": "^5.92.1",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.1.0"
+    },
+    "optionalDependencies": {
+        "@rspack/binding-linux-x64-gnu": "1.0.14"
     }
 }


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change adds an optional dependency for `@rspack/binding-linux-x64-gnu` version 1.0.14.