### PR TITLE
fix: added sass-embedded as optional dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -125,6 +125,7 @@
                 "raw-loader": "^4.0.2",
                 "rimraf": "^6.0.1",
                 "sass": "^1.80.4",
+                "sass-embedded": "^1.85.1",
                 "sass-loader": "^14.2.1",
                 "sass-resources-loader": "^2.2.5",
                 "stylelint": "^16.3.1",
@@ -145,7 +146,27 @@
                 "node": "18.x"
             },
             "optionalDependencies": {
-                "@rspack/binding-linux-x64-gnu": "1.0.14"
+                "@rspack/binding-linux-x64-gnu": "1.0.14",
+                "sass-embedded-android-arm": "1.85.1",
+                "sass-embedded-android-arm64": "1.85.1",
+                "sass-embedded-android-ia32": "1.85.1",
+                "sass-embedded-android-riscv64": "1.85.1",
+                "sass-embedded-android-x64": "1.85.1",
+                "sass-embedded-darwin-arm64": "1.85.1",
+                "sass-embedded-darwin-x64": "1.85.1",
+                "sass-embedded-linux-arm": "1.85.1",
+                "sass-embedded-linux-arm64": "1.85.1",
+                "sass-embedded-linux-ia32": "1.85.1",
+                "sass-embedded-linux-musl-arm": "1.85.1",
+                "sass-embedded-linux-musl-arm64": "1.85.1",
+                "sass-embedded-linux-musl-ia32": "1.85.1",
+                "sass-embedded-linux-musl-riscv64": "1.85.1",
+                "sass-embedded-linux-musl-x64": "1.85.1",
+                "sass-embedded-linux-riscv64": "1.85.1",
+                "sass-embedded-linux-x64": "1.85.1",
+                "sass-embedded-win32-arm64": "1.85.1",
+                "sass-embedded-win32-ia32": "1.85.1",
+                "sass-embedded-win32-x64": "1.85.1"
             }
         },
         "node_modules/@adobe/css-tools": {
@@ -22173,17 +22194,19 @@
             }
         },
         "node_modules/sass-embedded": {
-            "version": "1.80.5",
-            "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.80.5.tgz",
-            "integrity": "sha512-2rmFO02+NMk1no+OElI+H3+8wf0QDcbjmdIBATJhnPLKzbYbRt88U40rGN4pQWETFZ4hxppOGmGxn9MnHppHjw==",
+            "version": "1.85.1",
+            "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.85.1.tgz",
+            "integrity": "sha512-0i+3h2Df/c71afluxC1SXqyyMmJlnKWfu9ZGdzwuKRM1OftEa2XM2myt5tR36CF3PanYrMjFKtRIj8PfSf838w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@bufbuild/protobuf": "^2.0.0",
                 "buffer-builder": "^0.2.0",
                 "colorjs.io": "^0.5.0",
-                "immutable": "^4.0.0",
+                "immutable": "^5.0.2",
                 "rxjs": "^7.4.0",
                 "supports-color": "^8.1.1",
+                "sync-child-process": "^1.0.2",
                 "varint": "^6.0.0"
             },
             "bin": {
@@ -22193,36 +22216,116 @@
                 "node": ">=16.0.0"
             },
             "optionalDependencies": {
-                "sass-embedded-android-arm": "1.80.5",
-                "sass-embedded-android-arm64": "1.80.5",
-                "sass-embedded-android-ia32": "1.80.5",
-                "sass-embedded-android-riscv64": "1.80.5",
-                "sass-embedded-android-x64": "1.80.5",
-                "sass-embedded-darwin-arm64": "1.80.5",
-                "sass-embedded-darwin-x64": "1.80.5",
-                "sass-embedded-linux-arm": "1.80.5",
-                "sass-embedded-linux-arm64": "1.80.5",
-                "sass-embedded-linux-ia32": "1.80.5",
-                "sass-embedded-linux-musl-arm": "1.80.5",
-                "sass-embedded-linux-musl-arm64": "1.80.5",
-                "sass-embedded-linux-musl-ia32": "1.80.5",
-                "sass-embedded-linux-musl-riscv64": "1.80.5",
-                "sass-embedded-linux-musl-x64": "1.80.5",
-                "sass-embedded-linux-riscv64": "1.80.5",
-                "sass-embedded-linux-x64": "1.80.5",
-                "sass-embedded-win32-arm64": "1.80.5",
-                "sass-embedded-win32-ia32": "1.80.5",
-                "sass-embedded-win32-x64": "1.80.5"
+                "sass-embedded-android-arm": "1.85.1",
+                "sass-embedded-android-arm64": "1.85.1",
+                "sass-embedded-android-ia32": "1.85.1",
+                "sass-embedded-android-riscv64": "1.85.1",
+                "sass-embedded-android-x64": "1.85.1",
+                "sass-embedded-darwin-arm64": "1.85.1",
+                "sass-embedded-darwin-x64": "1.85.1",
+                "sass-embedded-linux-arm": "1.85.1",
+                "sass-embedded-linux-arm64": "1.85.1",
+                "sass-embedded-linux-ia32": "1.85.1",
+                "sass-embedded-linux-musl-arm": "1.85.1",
+                "sass-embedded-linux-musl-arm64": "1.85.1",
+                "sass-embedded-linux-musl-ia32": "1.85.1",
+                "sass-embedded-linux-musl-riscv64": "1.85.1",
+                "sass-embedded-linux-musl-x64": "1.85.1",
+                "sass-embedded-linux-riscv64": "1.85.1",
+                "sass-embedded-linux-x64": "1.85.1",
+                "sass-embedded-win32-arm64": "1.85.1",
+                "sass-embedded-win32-ia32": "1.85.1",
+                "sass-embedded-win32-x64": "1.85.1"
             }
         },
-        "node_modules/sass-embedded-darwin-arm64": {
-            "version": "1.80.5",
-            "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.80.5.tgz",
-            "integrity": "sha512-6P1suMeGiiSdbqwYNbCS4NbgFQaUMgvNMABydPfJ0KssTkFbpnPATQ5k8K1siZbxhw0kyxDbYMJebnpCS1lWbw==",
+        "node_modules/sass-embedded-android-arm": {
+            "version": "1.85.1",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.85.1.tgz",
+            "integrity": "sha512-GkcgUGMZtEF9gheuE1dxCU0ZSAifuaFXi/aX7ZXvjtdwmTl9Zc/OHR9oiUJkc8IW9UI7H8TuwlTAA8+SwgwIeQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-android-arm64": {
+            "version": "1.85.1",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.85.1.tgz",
+            "integrity": "sha512-27oRheqNA3SJM2hAxpVbs7mCKUwKPWmEEhyiNFpBINb5ELVLg+Ck5RsGg+SJmo130ul5YX0vinmVB5uPWc8X5w==",
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-android-ia32": {
+            "version": "1.85.1",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.85.1.tgz",
+            "integrity": "sha512-f3x16NyRgtXFksIaO/xXKrUhttUBv8V0XsAR2Dhdb/yz4yrDrhzw9Wh8fmw7PlQqECcQvFaoDr3XIIM6lKzasw==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-android-riscv64": {
+            "version": "1.85.1",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.85.1.tgz",
+            "integrity": "sha512-IP6OijpJ8Mqo7XqCe0LsuZVbAxEFVboa0kXqqR5K55LebEplsTIA2GnmRyMay3Yr/2FVGsZbCb6Wlgkw23eCiA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-android-x64": {
+            "version": "1.85.1",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.85.1.tgz",
+            "integrity": "sha512-Mh7CA53wR3ADvXAYipFc/R3vV4PVOzoKwWzPxmq+7i8UZrtsVjKONxGtqWe9JG1mna0C9CRZAx0sv/BzbOJxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-darwin-arm64": {
+            "version": "1.85.1",
+            "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.85.1.tgz",
+            "integrity": "sha512-msWxzhvcP9hqGVegxVePVEfv9mVNTlUgGr6k7O7Ihji702mbtrH/lKwF4aRkkt4g1j7tv10+JtQXmTNi/pi9kA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -22230,6 +22333,237 @@
             "engines": {
                 "node": ">=14.0.0"
             }
+        },
+        "node_modules/sass-embedded-darwin-x64": {
+            "version": "1.85.1",
+            "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.85.1.tgz",
+            "integrity": "sha512-J4UFHUiyI9Z+mwYMwz11Ky9TYr3hY1fCxeQddjNGL/+ovldtb0yAIHvoVM0BGprQDm5JqhtUk8KyJ3RMJqpaAA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-arm": {
+            "version": "1.85.1",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.85.1.tgz",
+            "integrity": "sha512-X0fDh95nNSw1wfRlnkE4oscoEA5Au4nnk785s9jghPFkTBg+A+5uB6trCjf0fM22+Iw6kiP4YYmDdw3BqxAKLQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-arm64": {
+            "version": "1.85.1",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.85.1.tgz",
+            "integrity": "sha512-jGadetB03BMFG2rq3OXub/uvC/lGpbQOiLGEz3NLb2nRZWyauRhzDtvZqkr6BEhxgIWtMtz2020yD8ZJSw/r2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-ia32": {
+            "version": "1.85.1",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.85.1.tgz",
+            "integrity": "sha512-7HlYY90d9mitDtNi5s+S+5wYZrTVbkBH2/kf7ixrzh2BFfT0YM81UHLJRnGX93y9aOMBL6DSZAIfkt1RsV9bkQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-musl-arm": {
+            "version": "1.85.1",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.85.1.tgz",
+            "integrity": "sha512-5vcdEqE8QZnu6i6shZo7x2N36V7YUoFotWj2rGekII5ty7Nkaj+VtZhUEOp9tAzEOlaFuDp5CyO1kUCvweT64A==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-musl-arm64": {
+            "version": "1.85.1",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.85.1.tgz",
+            "integrity": "sha512-FLkIT0p18XOkR6wryJ13LqGBDsrYev2dRk9dtiU18NCpNXruKsdBQ1ZnWHVKB3h1dA9lFyEEisC0sooKdNfeOQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-musl-ia32": {
+            "version": "1.85.1",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.85.1.tgz",
+            "integrity": "sha512-N1093T84zQJor1yyIAdYScB5eAuQarGK1tKgZ4uTnxVlgA7Xi1lXV8Eh7ox9sDqKCaWkVQ3MjqU26vYRBeRWyw==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-musl-riscv64": {
+            "version": "1.85.1",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.85.1.tgz",
+            "integrity": "sha512-WRsZS/7qlfYXsa93FBpSruieuURIu7ySfFhzYfF1IbKrNAGwmbduutkHZh2ddm5/vQMvQ0Rdosgv+CslaQHMcw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-musl-x64": {
+            "version": "1.85.1",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.85.1.tgz",
+            "integrity": "sha512-+OlLIilA5TnP0YEqTQ8yZtkW+bJIQYvzoGoNLUEskeyeGuOiIyn2CwL6G4JQB4xZQFaxPHb7JD3EueFkQbH0Pw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-riscv64": {
+            "version": "1.85.1",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.85.1.tgz",
+            "integrity": "sha512-mKKlOwMGLN7yP1p0gB5yG/HX4fYLnpWaqstNuOOXH+fOzTaNg0+1hALg0H0CDIqypPO74M5MS9T6FAJZGdT6dQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-x64": {
+            "version": "1.85.1",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.85.1.tgz",
+            "integrity": "sha512-uKRTv0z8NgtHV7xSren78+yoWB79sNi7TMqI7Bxd8fcRNIgHQSA8QBdF8led2ETC004hr8h71BrY60RPO+SSvA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-win32-arm64": {
+            "version": "1.85.1",
+            "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.85.1.tgz",
+            "integrity": "sha512-/GMiZXBOc6AEMBC3g25Rp+x8fq9Z6Ql7037l5rajBPhZ+DdFwtdHY0Ou3oIU6XuWUwD06U3ii4XufXVFhsP6PA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-win32-ia32": {
+            "version": "1.85.1",
+            "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.85.1.tgz",
+            "integrity": "sha512-L+4BWkKKBGFOKVQ2PQ5HwFfkM5FvTf1Xx2VSRvEWt9HxPXp6SPDho6zC8fqNQ3hSjoaoASEIJcSvgfdQYO0gdg==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-win32-x64": {
+            "version": "1.85.1",
+            "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.85.1.tgz",
+            "integrity": "sha512-/FO0AGKWxVfCk4GKsC0yXWBpUZdySe3YAAbQQL0lL6xUd1OiUY8Kow6g4Kc1TB/+z0iuQKKTqI/acJMEYl4iTQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded/node_modules/immutable": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
+            "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/sass-embedded/node_modules/supports-color": {
             "version": "8.1.1",
@@ -24666,6 +25000,29 @@
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+        },
+        "node_modules/sync-child-process": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz",
+            "integrity": "sha512-8lD+t2KrrScJ/7KXCSyfhT3/hRq78rC0wBFqNJXv3mZyn6hW2ypM05JmlSvtqRbeq6jqA94oHbxAr2vYsJ8vDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sync-message-port": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/sync-message-port": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sync-message-port/-/sync-message-port-1.1.3.tgz",
+            "integrity": "sha512-GTt8rSKje5FilG+wEdfCkOcLL7LWqpMlr2c3LRuKt/YXxcJ52aGSbGBAdI4L3aaqfrBt6y711El53ItyH1NWzg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
+            }
         },
         "node_modules/synckit": {
             "version": "0.9.2",

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
         "raw-loader": "^4.0.2",
         "rimraf": "^6.0.1",
         "sass": "^1.80.4",
+        "sass-embedded": "^1.85.1",
         "sass-loader": "^14.2.1",
         "sass-resources-loader": "^2.2.5",
         "stylelint": "^16.3.1",
@@ -154,6 +155,26 @@
         "webpack-dev-server": "^5.1.0"
     },
     "optionalDependencies": {
-        "@rspack/binding-linux-x64-gnu": "1.0.14"
+        "@rspack/binding-linux-x64-gnu": "1.0.14",
+        "sass-embedded-android-arm": "1.85.1",
+        "sass-embedded-android-arm64": "1.85.1",
+        "sass-embedded-android-ia32": "1.85.1",
+        "sass-embedded-android-riscv64": "1.85.1",
+        "sass-embedded-android-x64": "1.85.1",
+        "sass-embedded-darwin-arm64": "1.85.1",
+        "sass-embedded-darwin-x64": "1.85.1",
+        "sass-embedded-linux-arm": "1.85.1",
+        "sass-embedded-linux-arm64": "1.85.1",
+        "sass-embedded-linux-ia32": "1.85.1",
+        "sass-embedded-linux-musl-arm": "1.85.1",
+        "sass-embedded-linux-musl-arm64": "1.85.1",
+        "sass-embedded-linux-musl-ia32": "1.85.1",
+        "sass-embedded-linux-musl-riscv64": "1.85.1",
+        "sass-embedded-linux-musl-x64": "1.85.1",
+        "sass-embedded-linux-riscv64": "1.85.1",
+        "sass-embedded-linux-x64": "1.85.1",
+        "sass-embedded-win32-arm64": "1.85.1",
+        "sass-embedded-win32-ia32": "1.85.1",
+        "sass-embedded-win32-x64": "1.85.1"
     }
 }


### PR DESCRIPTION
This pull request includes updates to the `package.json` file to add support for various embedded Sass versions. The most important changes are the addition of the `sass-embedded` package and several optional dependencies for different platforms.

Dependency updates:

* Added `sass-embedded` version `^1.85.1` to the dependencies section.
* Added multiple `sass-embedded` versions for different platforms to the optional dependencies section.