### PR TITLE
fix: remove query param on logout

### DIFF
--- a/src/app/CoreStoreProvider.tsx
+++ b/src/app/CoreStoreProvider.tsx
@@ -105,6 +105,9 @@ const CoreStoreProvider: React.FC<{ children: React.ReactNode }> = observer(({ c
                 error?.code === 'InvalidToken'
             ) {
                 await oAuthLogout();
+                if (sessionStorage.getItem('query_param_currency')) {
+                    sessionStorage.removeItem('query_param_currency');
+                }
             }
 
             if (msg_type === 'balance' && data && !error) {

--- a/src/hooks/auth/useOauth2.ts
+++ b/src/hooks/auth/useOauth2.ts
@@ -42,6 +42,9 @@ export const useOauth2 = ({
     const logoutHandler = async () => {
         client?.setIsLoggingOut(true);
         await oAuthLogout();
+        if (sessionStorage.getItem('query_param_currency')) {
+            sessionStorage.removeItem('query_param_currency');
+        }
     };
 
     return { isOAuth2Enabled, oAuthLogout: logoutHandler };


### PR DESCRIPTION
This pull request includes changes to ensure that the `query_param_currency` is removed from `sessionStorage` upon logging out. This update affects both the `CoreStoreProvider` component and the `useOauth2` hook.

Changes to session storage management:

* [`src/app/CoreStoreProvider.tsx`](diffhunk://#diff-5ec7969cf78888b570b3224805b4252b136ff69101053e09e361de4be5cdded8R108-R110): Added logic to remove `query_param_currency` from `sessionStorage` during the OAuth logout process.
* [`src/hooks/auth/useOauth2.ts`](diffhunk://#diff-7ed7d4a03c35423f9e58a16d28f0b5af98eee2e3f4e729a311f562cd8b5d268bR45-R47): Added logic to remove `query_param_currency` from `sessionStorage` in the `logoutHandler` function.