### PR TITLE
fix: added for toast notification

### DIFF
--- a/src/stores/run-panel-store.ts
+++ b/src/stores/run-panel-store.ts
@@ -141,16 +141,26 @@ export default class RunPanelStore {
 
     setShowBotStopMessage = (show_bot_stop_message: boolean) => {
         this.show_bot_stop_message = show_bot_stop_message;
-        if (show_bot_stop_message)
-            botNotification(notification_message().bot_stop, {
-                label: localize('Reports'),
-                onClick: () => {
-                    const contract_type = getSelectedTradeType();
-                    const url = new URL(standalone_routes.positions);
-                    url.searchParams.set('contract_type_bots', contract_type);
-                    window.location.assign(url.toString());
-                },
-            });
+        if (!show_bot_stop_message) return;
+        const handleNotificationClick = () => {
+            const contract_type = getSelectedTradeType();
+            const url = new URL(standalone_routes.positions);
+            url.searchParams.set('contract_type_bots', contract_type);
+
+            const getQueryParams = new URLSearchParams(window.location.search);
+            const account = getQueryParams.get('account') || sessionStorage.getItem('query_param_currency') || '';
+
+            if (account) {
+                url.searchParams.set('account', account);
+            }
+
+            window.location.assign(url.toString());
+        };
+
+        botNotification(notification_message().bot_stop, {
+            label: localize('Reports'),
+            onClick: handleNotificationClick,
+        });
     };
 
     performSelfExclusionCheck = async () => {


### PR DESCRIPTION
This pull request includes a modification to the `RunPanelStore` class in `src/stores/run-panel-store.ts` to improve the handling of bot stop notifications. The primary change involves refactoring the `setShowBotStopMessage` method for better readability and functionality.

Key changes:

* [`src/stores/run-panel-store.ts`](diffhunk://#diff-896fc35ee731169d31b53e8b911d8fd8b93d382a639ea1a3967ba325e0a251e8L144-R162): Refactored the `setShowBotStopMessage` method to introduce a new function `handleNotificationClick` for improved readability and added logic to handle query parameters for the account.