### PR TITLE
fix: redirection on account profile

### DIFF
--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -42,17 +42,29 @@ const AppHeader = observer(() => {
             return (
                 <>
                     {/* <CustomNotifications /> */}
-                    {isDesktop && (
-                        <Tooltip
-                            as='a'
-                            href={standalone_routes.personal_details}
-                            tooltipContent={localize('Manage account settings')}
-                            tooltipPosition='bottom'
-                            className='app-header__account-settings'
-                        >
-                            <StandaloneCircleUserRegularIcon className='app-header__profile_icon' />
-                        </Tooltip>
-                    )}
+                    {isDesktop &&
+                        (() => {
+                            const redirect_url = new URL(standalone_routes.personal_details);
+                            const is_virtual = client?.is_virtual;
+                            if (is_virtual) {
+                                // For demo accounts, set the account parameter to 'demo'
+                                redirect_url.searchParams.set('account', 'demo');
+                            } else if (currency) {
+                                // For real accounts, set the account parameter to the currency
+                                redirect_url.searchParams.set('account', currency);
+                            }
+                            return (
+                                <Tooltip
+                                    as='a'
+                                    href={redirect_url.toString()}
+                                    tooltipContent={localize('Manage account settings')}
+                                    tooltipPosition='bottom'
+                                    className='app-header__account-settings'
+                                >
+                                    <StandaloneCircleUserRegularIcon className='app-header__profile_icon' />
+                                </Tooltip>
+                            );
+                        })()}
                     <AccountSwitcher activeAccount={activeAccount} />
                     {isDesktop &&
                         (has_wallet ? (

--- a/src/components/layout/header/mobile-menu/use-mobile-menu-config.tsx
+++ b/src/components/layout/header/mobile-menu/use-mobile-menu-config.tsx
@@ -51,6 +51,27 @@ const useMobileMenuConfig = (client?: RootStore['client']) => {
     const { is_livechat_available } = useIsLiveChatWidgetAvailable();
     const icAvailable = useIsIntercomAvailable();
 
+    // Function to add account parameter to URLs
+    const getAccountUrl = (url: string) => {
+        try {
+            const redirect_url = new URL(url);
+            const is_virtual = client?.is_virtual;
+            const currency = client?.getCurrency?.();
+
+            if (is_virtual) {
+                // For demo accounts, set the account parameter to 'demo'
+                redirect_url.searchParams.set('account', 'demo');
+            } else if (currency) {
+                // For real accounts, set the account parameter to the currency
+                redirect_url.searchParams.set('account', currency);
+            }
+
+            return redirect_url.toString();
+        } catch (error) {
+            return url;
+        }
+    };
+
     const menuConfig: TMenuConfig[] = [
         [
             {
@@ -73,7 +94,7 @@ const useMobileMenuConfig = (client?: RootStore['client']) => {
             },
             {
                 as: 'a',
-                href: standalone_routes.personal_details,
+                href: getAccountUrl(standalone_routes.personal_details),
                 label: localize('Account Settings'),
                 LeftComponent: LegacyProfileSmIcon,
             },


### PR DESCRIPTION
This pull request includes changes to enhance URL handling by adding account parameters based on the account type (demo or real) and currency. The changes are implemented in both the desktop and mobile menu configurations.

Enhancements to URL handling:

* [`src/components/layout/header/header.tsx`](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3L45-R67): Modified the `AppHeader` component to dynamically set the account parameter in the URL for account settings based on whether the account is a demo or real account.

* [`src/components/layout/header/mobile-menu/use-mobile-menu-config.tsx`](diffhunk://#diff-d1dbf017cbc6be00aadfd73ef141a2bfdf9f90b8464e96f24ae4f7870bdf6477R54-R74): Added a `getAccountUrl` function to append the account parameter to URLs and updated the mobile menu configuration to use this function for the account settings link. [[1]](diffhunk://#diff-d1dbf017cbc6be00aadfd73ef141a2bfdf9f90b8464e96f24ae4f7870bdf6477R54-R74) [[2]](diffhunk://#diff-d1dbf017cbc6be00aadfd73ef141a2bfdf9f90b8464e96f24ae4f7870bdf6477L76-R97)