### PR TITLE
fix: Fix--to-remove-the-accoumulator-ticks

### DIFF
--- a/src/components/shared_ui/contract-card/contract-card-items/contract-card-header.tsx
+++ b/src/components/shared_ui/contract-card/contract-card-items/contract-card-header.tsx
@@ -168,13 +168,7 @@ const ContractCardHeader = ({
                     ) : null}
                 </MobileWrapper>
             </div>
-            {!is_sold && is_accumulator && (
-                <TickCounterBar
-                    current_tick={tick_passed}
-                    max_ticks_duration={tick_count}
-                    label={getCardLabels().TICKS}
-                />
-            )}
+            {!is_sold && is_accumulator && <TickCounterBar current_tick={tick_passed} label={getCardLabels().TICKS} />}
             <MobileWrapper>
                 <div className='dc-progress-slider--completed' />
             </MobileWrapper>

--- a/src/components/shared_ui/contract-card/contract-card-items/tick-counter-bar.tsx
+++ b/src/components/shared_ui/contract-card/contract-card-items/tick-counter-bar.tsx
@@ -4,13 +4,12 @@ import Text from '../../text';
 type TTickCounterBar = {
     current_tick?: number;
     label: string;
-    max_ticks_duration?: number;
 };
-const TickCounterBar = ({ current_tick, label, max_ticks_duration }: TTickCounterBar) => (
+const TickCounterBar = ({ current_tick, label }: TTickCounterBar) => (
     <div className='dc-tick-counter-bar__container'>
         <div className='dc-tick-counter-bar__track'>
             <Text size='xxs' weight='bold' align='center' color='profit-success' className='dc-tick-counter-bar__text'>
-                {`${current_tick}/${max_ticks_duration} ${label}`}
+                {`${current_tick} ${label}`}
             </Text>
         </div>
     </div>


### PR DESCRIPTION
This pull request includes changes to simplify the `TickCounterBar` component and its usage in the `ContractCardHeader` component by removing the `max_ticks_duration` property.

Simplification of `TickCounterBar` component:

* [`src/components/shared_ui/contract-card/contract-card-items/tick-counter-bar.tsx`](diffhunk://#diff-542f357a5df96224006f321a8261ebf621f800d7ae6a12b51d1239ca5b3258b5L7-R12): Removed the `max_ticks_duration` property from the `TTickCounterBar` type and the `TickCounterBar` component. Updated the displayed text to exclude `max_ticks_duration`.

Usage updates in `ContractCardHeader` component:

* [`src/components/shared_ui/contract-card/contract-card-items/contract-card-header.tsx`](diffhunk://#diff-b3c61714a88e9337cb3c53e07aa67d1fa4403de82014f686263dd1759bf37169L171-R171): Updated the `TickCounterBar` usage to exclude the `max_ticks_duration` property.