### PR TITLE
fix: input validations

### DIFF
--- a/src/pages/bot-builder/quick-strategy/config.ts
+++ b/src/pages/bot-builder/quick-strategy/config.ts
@@ -69,6 +69,16 @@ const TAKE_PROFIT = (): TConfigItem => ({
     hide_without_should_have: true,
     attached: true,
     has_currency_unit: true,
+    validation: [
+        'number',
+        'required',
+        'ceil',
+        {
+            type: 'min',
+            value: 0.35,
+            getMessage: (min: string | number) => localize('Minimum take profit allowed is {{ min }}', { min }),
+        },
+    ],
 });
 
 const TICK_COUNT = (): TConfigItem => ({
@@ -78,6 +88,16 @@ const TICK_COUNT = (): TConfigItem => ({
     hide_without_should_have: true,
     attached: true,
     has_currency_unit: false,
+    validation: [
+        'number',
+        'required',
+        'ceil',
+        {
+            type: 'min',
+            value: 1,
+            getMessage: (min: string | number) => localize('Minimum tick count allowed is {{ min }}', { min }),
+        },
+    ],
 });
 
 const NUMBER_DEFAULT_VALIDATION = (): TValidationItem => ({
@@ -130,7 +150,23 @@ const LABEL_STAKE = (): TConfigItem => ({
 const STAKE = (): TConfigItem => ({
     type: 'number',
     name: 'stake',
-    validation: ['number', 'required', 'ceil', NUMBER_DEFAULT_VALIDATION()],
+    validation: [
+        'number',
+        'required',
+        'ceil',
+        {
+            type: 'min',
+            value: 0.35,
+            getMessage: (min: string | number) => localize('Minimum stake allowed is {{ min }}', { min }),
+            getDynamicValue: (store: any) => store.quick_strategy?.additional_data?.min_stake || 0.35,
+        },
+        {
+            type: 'max',
+            value: 1000,
+            getMessage: (max: string | number) => localize('Maximum stake allowed is {{ max }}', { max }),
+            getDynamicValue: (store: any) => store.quick_strategy?.additional_data?.max_stake || 1000,
+        },
+    ],
     has_currency_unit: true,
 });
 

--- a/src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx
+++ b/src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx
@@ -100,10 +100,14 @@ const QSInput: React.FC<TQSInput> = observer(
                                         leading_icon={
                                             is_number ? (
                                                 <button
-                                                    disabled={disabled || (!!min && field.value <= min)}
+                                                    disabled={disabled || (!!min && Number(field.value) === min)}
                                                     data-testid='qs-input-decrease'
                                                     onClick={(e: MouseEvent<HTMLButtonElement>) => {
-                                                        const value = Number(field.value) - 1;
+                                                        let value = Number(field.value) - 1;
+                                                        // Ensure the value doesn't go below the minimum
+                                                        if (!!min && value < min) {
+                                                            value = min;
+                                                        }
                                                         handleButtonInputChange(
                                                             e,
                                                             String(value % 1 ? value.toFixed(2) : value)

--- a/src/pages/bot-builder/quick-strategy/quick-strategy.tsx
+++ b/src/pages/bot-builder/quick-strategy/quick-strategy.tsx
@@ -166,10 +166,12 @@ const FormikWrapper: React.FC<TFormikWrapper> = observer(({ children }) => {
                                     }
                                 } else if (typeof validation === 'object') {
                                     if (validation?.type) {
-                                        schema = schema[validation.type](
-                                            validation.value,
-                                            localize(validation.getMessage(validation.value))
-                                        );
+                                        // Use dynamic value if available
+                                        const value = validation.getDynamicValue
+                                            ? validation.getDynamicValue(quick_strategy)
+                                            : validation.value;
+
+                                        schema = schema[validation.type](value, localize(validation.getMessage(value)));
                                     }
                                 }
                             });

--- a/src/pages/bot-builder/quick-strategy/types.ts
+++ b/src/pages/bot-builder/quick-strategy/types.ts
@@ -15,6 +15,7 @@ export type TValidationType = 'min' | 'max' | 'required' | 'number' | 'ceil' | '
 
 export interface ValidationObject {
     getMessage: (min: number | string) => string;
+    getDynamicValue?: (store: any) => number;
 }
 
 export type TValidationItem =
@@ -34,7 +35,7 @@ export type TConfigItem = Partial<{
     name: keyof TFormData;
     dependencies: string[];
     label: string;
-    description: ReactNode;
+    description: ReactNode | ((additional_data: any) => ReactNode);
     attached: boolean;
     hide: string[];
     validation: TValidationItem[];


### PR DESCRIPTION
This pull request includes several changes to the validation logic and error handling in the bot-builder quick-strategy configuration. The most important changes include adding dynamic validation values, improving error messages, and ensuring values do not go below the minimum.

### Validation Enhancements:
* Added dynamic validation values for `STAKE`, allowing minimum and maximum values to be dynamically set based on the store's `quick_strategy` data. (`src/pages/bot-builder/quick-strategy/config.ts`)
* Introduced `getDynamicValue` in the `ValidationObject` interface to support dynamic validation values. (`src/pages/bot-builder/quick-strategy/types.ts`)

### Error Handling Improvements:
* Enhanced error messages for `tick_count` and `stake` fields by extracting values from API responses and ensuring more accurate and user-friendly messages. (`src/pages/bot-builder/quick-strategy/selects/growth-rate-type.tsx`) [[1]](diffhunk://#diff-2dadc92b761e0f8352aa0d3f0bc6c128b1a7b8556223523a66d06fcc5362a24bR92-R104) [[2]](diffhunk://#diff-2dadc92b761e0f8352aa0d3f0bc6c128b1a7b8556223523a66d06fcc5362a24bR155-R181)
* Modified the `FormikWrapper` to use dynamic validation values if available, improving the flexibility of validation logic. (`src/pages/bot-builder/quick-strategy/quick-strategy.tsx`)

### Value Constraints:
* Ensured that the `qs-input` component does not allow values to go below the minimum by adjusting the decrement button logic. (`src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx`)