### PR TITLE
fix: decimal digit

### DIFF
--- a/src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx
+++ b/src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx
@@ -146,6 +146,17 @@ const QSInput: React.FC<TQSInput> = observer(
                                         bottom_label={is_exclusive_field ? currency : ''}
                                         max_characters={2}
                                         maxLength={2}
+                                        inputMode={name === 'tick_count' ? 'numeric' : undefined}
+                                        pattern={name === 'tick_count' ? '[0-9]*' : undefined}
+                                        onKeyPress={
+                                            name === 'tick_count'
+                                                ? e => {
+                                                      if (e.key === '.') {
+                                                          e.preventDefault();
+                                                      }
+                                                  }
+                                                : undefined
+                                        }
                                     />
                                 </Popover>
                             </div>


### PR DESCRIPTION
This pull request includes a small change to the `src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx` file. The change ensures that the `tick_count` input field only accepts numeric values.

* [`src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx`](diffhunk://#diff-a5d6442de8ce7ac0e7af26611c486cceb1e7537c2a57284449af9a42f88802e2R149-R159): Added `inputMode`, `pattern`, and `onKeyPress` properties to restrict `tick_count` input to numeric values only.