### PR TITLE
fix: qs bugs

### DIFF
--- a/src/pages/bot-builder/quick-strategy/config.ts
+++ b/src/pages/bot-builder/quick-strategy/config.ts
@@ -187,7 +187,7 @@ const DURATION = (): TConfigItem => ({
     type: 'number',
     name: 'duration',
     attached: true,
-    validation: ['number', 'required', 'min', 'max'],
+    validation: ['number', 'required', 'min', 'max', 'integer'],
 });
 
 const LABEL_PROFIT = (): TConfigItem => ({

--- a/src/pages/bot-builder/quick-strategy/form.tsx
+++ b/src/pages/bot-builder/quick-strategy/form.tsx
@@ -43,6 +43,13 @@ const QuickStrategyForm = observer(() => {
         };
     }, []);
 
+    // Ensure toggle switch state is synchronized with form values
+    React.useEffect(() => {
+        if (values?.boolean_max_stake !== undefined) {
+            setIsEnabledToggleSwitch(!!values.boolean_max_stake);
+        }
+    }, [values?.boolean_max_stake]);
+
     React.useEffect(() => {
         if (!isEnabledToggleSwitch && values?.max_stake) {
             setFieldValue('max_stake', 0);
@@ -53,6 +60,31 @@ const QuickStrategyForm = observer(() => {
         setValue(key, value);
         await setFieldTouched(key, true, true);
         await setFieldValue(key, value, true);
+
+        // Cross-validate stake and max_stake when either value changes
+        if (key === 'stake' || key === 'max_stake') {
+            // Always re-validate both fields when either changes
+            // This ensures error messages are cleared when values are corrected
+            setFieldTouched('stake', true, true);
+            setFieldTouched('max_stake', true, true);
+
+            // Force immediate validation
+            if (key === 'stake') {
+                // When stake changes, we need to validate max_stake as well
+                const input_elements = document.querySelectorAll('input[name="max_stake"]');
+                if (input_elements.length > 0) {
+                    const event = new Event('keyup', { bubbles: true });
+                    input_elements[0].dispatchEvent(event);
+                }
+            } else if (key === 'max_stake') {
+                // When max_stake changes, we need to validate stake as well
+                const input_elements = document.querySelectorAll('input[name="stake"]');
+                if (input_elements.length > 0) {
+                    const event = new Event('keyup', { bubbles: true });
+                    input_elements[0].dispatchEvent(event);
+                }
+            }
+        }
     };
 
     const handleEnter = (event: KeyboardEvent) => {
@@ -164,7 +196,7 @@ const QuickStrategyForm = observer(() => {
                                     <QSInputLabel
                                         key={key}
                                         label={field.label}
-                                        description={field.description ?? ''}
+                                        description={field.description ? String(field.description) : ''}
                                         additional_data={additional_data}
                                     />
                                 );
@@ -172,10 +204,10 @@ const QuickStrategyForm = observer(() => {
                             case 'checkbox':
                                 return (
                                     <QSCheckbox
-                                        {...field}
                                         key={key}
                                         name={field.name as string}
                                         label={field.label as string}
+                                        description={field.description ? String(field.description) : undefined}
                                         isEnabledToggleSwitch={!!isEnabledToggleSwitch}
                                         setIsEnabledToggleSwitch={toggleSwitch}
                                     />

--- a/src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx
+++ b/src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx
@@ -118,7 +118,7 @@ const QSInput: React.FC<TQSInput> = observer(
                 } else {
                     // Show error message if value is less than minimum stake
                     if (numValue < min_stake) {
-                        setErrorMessage(`Minimum stake allowed is 0.35`);
+                        setErrorMessage(`Minimum stake allowed is ${min_stake}`);
                     } else if (numValue > max_stake) {
                         // Allow entering any value but show error message
                         setErrorMessage(`Maximum stake allowed is ${max_stake}`);
@@ -147,7 +147,7 @@ const QSInput: React.FC<TQSInput> = observer(
                 } else {
                     // Show error message if value is less than minimum stake
                     if (numValue < min_stake) {
-                        setErrorMessage(`Minimum stake allowed is 0.35`);
+                        setErrorMessage(`Minimum stake allowed is ${min_stake}`);
                     } else if (numValue > max_stake) {
                         // Allow entering any value but show error message
                         setErrorMessage(`Maximum stake allowed is ${max_stake}`);
@@ -350,10 +350,8 @@ const QSInput: React.FC<TQSInput> = observer(
                                         onKeyUp={e => {
                                             // Check value on each keystroke for stake field
                                             if (name === 'stake' || name === 'max_stake') {
-                                                const min_stake =
-                                                    (quick_strategy?.additional_data as any)?.min_stake || 0.35;
-                                                const max_stake =
-                                                    (quick_strategy?.additional_data as any)?.max_stake || 1000;
+                                                const min_stake = (quick_strategy?.additional_data as any)?.min_stake;
+                                                const max_stake = (quick_strategy?.additional_data as any)?.max_stake;
                                                 const value = e.currentTarget.value;
 
                                                 // For empty values, show error message but don't reset
@@ -372,7 +370,7 @@ const QSInput: React.FC<TQSInput> = observer(
 
                                                 // Show error message if value is less than minimum stake or greater than maximum
                                                 if (numValue < min_stake) {
-                                                    setErrorMessage(`Minimum stake allowed is 0.35`);
+                                                    setErrorMessage(`Minimum stake allowed is ${min_stake}`);
                                                 } else if (numValue > max_stake) {
                                                     // Allow entering any value but show error message for maximum
                                                     setErrorMessage(`Maximum stake allowed is ${max_stake}`);

--- a/src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx
+++ b/src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx
@@ -244,6 +244,11 @@ const QSInput: React.FC<TQSInput> = observer(
                 value = Math.floor(Number(value));
             }
 
+            // For all number fields, prevent decimal values less than 1
+            if (is_number && typeof value === 'number' && value < 1 && !Number.isInteger(value)) {
+                value = 1;
+            }
+
             // For stake field, check if value is within the allowed range
             if (name === 'stake' && is_number) {
                 const min_stake = (quick_strategy?.additional_data as any)?.min_stake || 0.35;
@@ -434,6 +439,13 @@ const QSInput: React.FC<TQSInput> = observer(
                                                 } else {
                                                     // For non-empty values, validate and show appropriate message
                                                     const numValue = Number(value);
+
+                                                    // Prevent decimal values less than 1
+                                                    if (numValue < 1 && !Number.isInteger(numValue)) {
+                                                        setFieldValue(name, 1);
+                                                        return;
+                                                    }
+
                                                     if (numValue < min_stake) {
                                                         setErrorMessage(`Minimum stake allowed is ${min_stake}`);
                                                     } else if (numValue > max_stake) {
@@ -546,6 +558,12 @@ const QSInput: React.FC<TQSInput> = observer(
                                                 }
 
                                                 const numValue = Number(value);
+
+                                                // Prevent decimal values less than 1
+                                                if (numValue < 1 && !Number.isInteger(numValue)) {
+                                                    setFieldValue(name, 1);
+                                                    return;
+                                                }
 
                                                 // Clear error message if value is valid
                                                 if (numValue >= min_stake && numValue <= max_stake) {

--- a/src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx
+++ b/src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx
@@ -125,14 +125,8 @@ const QSInput: React.FC<TQSInput> = observer(
                     }
                 }
 
-                // Cross-validate with max_stake
-                const max_stake_value = values.max_stake;
-                if (max_stake_value && Number(max_stake_value) < numValue) {
-                    // If max stake is less than initial stake, show error
-                    setErrorMessage(
-                        `Initial stake (${numValue}) cannot be greater than max stake (${max_stake_value})`
-                    );
-                }
+                ``; // Note: We're not adding a custom error message for when initial stake > max stake
+                // The standard error message will be displayed by the form validation
             }
 
             // For max_stake field, check if value is within the allowed range
@@ -296,17 +290,8 @@ const QSInput: React.FC<TQSInput> = observer(
                                                     }
                                                 }
 
-                                                // Cross-validate with the other stake field
-                                                if (name === 'stake') {
-                                                    // When initial stake changes, validate max_stake
-                                                    const max_stake_value = values.max_stake;
-                                                    if (max_stake_value && Number(max_stake_value) < Number(value)) {
-                                                        // If max stake is less than initial stake, show error
-                                                        setErrorMessage(
-                                                            `Initial stake (${value}) cannot be greater than max stake (${max_stake_value})`
-                                                        );
-                                                    }
-                                                } else if (name === 'max_stake') {
+                                                // Only validate max_stake against initial stake
+                                                if (name === 'max_stake') {
                                                     // When max stake changes, validate initial stake
                                                     const initial_stake_value = values.stake;
                                                     if (
@@ -319,6 +304,8 @@ const QSInput: React.FC<TQSInput> = observer(
                                                         );
                                                     }
                                                 }
+                                                // Note: We're not adding a custom error message for when initial stake > max stake
+                                                // The standard error message will be displayed by the form validation
                                             }
                                         }}
                                         placeholder={is_exclusive_field ? '0.00' : ''}
@@ -376,17 +363,8 @@ const QSInput: React.FC<TQSInput> = observer(
                                                     setErrorMessage(`Maximum stake allowed is ${max_stake}`);
                                                 }
 
-                                                // Cross-validate with the other stake field
-                                                if (name === 'stake') {
-                                                    // When initial stake changes, validate max_stake
-                                                    const max_stake_value = values.max_stake;
-                                                    if (max_stake_value && Number(max_stake_value) < numValue) {
-                                                        // If max stake is less than initial stake, show error
-                                                        setErrorMessage(
-                                                            `Initial stake (${numValue}) cannot be greater than max stake (${max_stake_value})`
-                                                        );
-                                                    }
-                                                } else if (name === 'max_stake') {
+                                                // Only validate max_stake against initial stake
+                                                if (name === 'max_stake') {
                                                     // When max stake changes, validate initial stake
                                                     const initial_stake_value = values.stake;
                                                     if (initial_stake_value && Number(initial_stake_value) > numValue) {
@@ -396,6 +374,8 @@ const QSInput: React.FC<TQSInput> = observer(
                                                         );
                                                     }
                                                 }
+                                                // Note: We're not adding a custom error message for when initial stake > max stake
+                                                // The standard error message will be displayed by the form validation
                                             }
                                         }}
                                     />

--- a/src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx
+++ b/src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx
@@ -325,7 +325,8 @@ const QSInput: React.FC<TQSInput> = observer(
                                             name === 'loss' ||
                                             name === 'profit' ||
                                             name === 'take_profit' ||
-                                            name === 'tick_count')
+                                            name === 'tick_count' ||
+                                            name === 'size')
                                     } // Show error message for all input fields that need validation
                                     zIndex='9999'
                                     classNameBubble='qs__warning-bubble'

--- a/src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx
+++ b/src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx
@@ -5,7 +5,6 @@ import { observer } from 'mobx-react-lite';
 import Input from '@/components/shared_ui/input';
 import Popover from '@/components/shared_ui/popover';
 import { useStore } from '@/hooks/useStore';
-import { useDevice } from '@deriv-com/ui';
 
 type TQSInput = {
     name: string;
@@ -35,15 +34,34 @@ const QSInput: React.FC<TQSInput> = observer(
         } = useStore();
         const { quick_strategy } = useStore();
         const { loss_threshold_warning_data } = quick_strategy;
-        const { isDesktop } = useDevice();
 
-        const [has_focus, setFocus] = React.useState(false);
+        const [, setFocus] = React.useState(false);
+        const [error_message, setErrorMessage] = React.useState<string | null>(null);
         const { setFieldValue, setFieldTouched } = useFormikContext();
         const is_number = type === 'number';
         const max_value = 999999999999;
 
         const handleButtonInputChange = (e: MouseEvent<HTMLButtonElement>, value: string) => {
             e?.preventDefault();
+
+            // For tick_count field or duration field with ticks, ensure we only allow integer values
+            if (name === 'tick_count' || (name === 'duration' && quick_strategy.form_data?.durationtype === 't')) {
+                const intValue = Math.floor(Number(value));
+                value = String(intValue);
+            }
+
+            // For stake field, ensure the value is within the allowed range
+            if (name === 'stake') {
+                const min_stake = (quick_strategy?.additional_data as any)?.min_stake || 0.35;
+                const max_stake = (quick_strategy?.additional_data as any)?.max_stake || 1000;
+
+                if (Number(value) < min_stake) {
+                    value = String(min_stake);
+                } else if (Number(value) > max_stake) {
+                    value = String(max_stake);
+                }
+            }
+
             onChange(name, value);
             setFieldTouched(name, true, true);
             setFieldValue(name, value);
@@ -53,12 +71,72 @@ const QSInput: React.FC<TQSInput> = observer(
             const input_value = e.target.value;
             let value: number | string = 0;
             const max_characters = 12;
+
+            // Clear any previous error message
+            setErrorMessage(null);
+
+            // Allow empty string or partial input to support backspace
+            if (input_value === '' || input_value === '0' || input_value === '0.') {
+                onChange(name, input_value);
+                return;
+            }
+
             if (max_characters && input_value.length >= max_characters) {
                 value = input_value.slice(0, max_characters);
                 value = is_number ? Number(value) : value;
             } else {
                 value = is_number ? Number(input_value) : input_value;
             }
+
+            // For tick_count field or duration field with ticks, ensure we only allow integer values
+            if (
+                is_number &&
+                (name === 'tick_count' || (name === 'duration' && quick_strategy.form_data?.durationtype === 't')) &&
+                !Number.isInteger(value)
+            ) {
+                value = Math.floor(Number(value));
+            }
+
+            // For stake field, check if value is within the allowed range
+            if (name === 'stake' && is_number) {
+                const min_stake = (quick_strategy?.additional_data as any)?.min_stake || 0.35;
+                const max_stake = (quick_strategy?.additional_data as any)?.max_stake || 1000;
+                const numValue = Number(value);
+
+                // Clear error message if value is valid
+                if (numValue >= min_stake && numValue <= max_stake) {
+                    setErrorMessage(null);
+                } else {
+                    // Show error message if value is less than minimum stake
+                    if (numValue < min_stake) {
+                        setErrorMessage(`Minimum stake allowed is 0.35`);
+                    } else if (numValue > max_stake) {
+                        // Allow entering any value but show error message
+                        setErrorMessage(`Maximum stake allowed is ${max_stake}`);
+                    }
+                }
+            }
+
+            // For max_stake field, check if value is within the allowed range
+            if (name === 'max_stake' && is_number) {
+                const min_stake = (quick_strategy?.additional_data as any)?.min_stake || 0.35;
+                const max_stake = (quick_strategy?.additional_data as any)?.max_stake || 1000;
+                const numValue = Number(value);
+
+                // Clear error message if value is valid
+                if (numValue >= min_stake && numValue <= max_stake) {
+                    setErrorMessage(null);
+                } else {
+                    // Show error message if value is less than minimum stake
+                    if (numValue < min_stake) {
+                        setErrorMessage(`Minimum stake allowed is 0.35`);
+                    } else if (numValue > max_stake) {
+                        // Allow entering any value but show error message
+                        setErrorMessage(`Maximum stake allowed is ${max_stake}`);
+                    }
+                }
+            }
+
             onChange(name, value);
         };
 
@@ -82,8 +160,8 @@ const QSInput: React.FC<TQSInput> = observer(
                             >
                                 <Popover
                                     alignment='bottom'
-                                    message={error}
-                                    is_open={!isDesktop ? !!error : !!error && has_focus}
+                                    message={error || error_message} // Prioritize backend error over client-side error
+                                    is_open={!!(error || error_message) && (name === 'stake' || name === 'max_stake')} // Show error message for stake and max_stake fields
                                     zIndex='9999'
                                     classNameBubble='qs__warning-bubble'
                                     has_error
@@ -93,25 +171,52 @@ const QSInput: React.FC<TQSInput> = observer(
                                         data_testId='qs-input'
                                         className={classNames(
                                             'qs__input',
-                                            { error: has_error },
+                                            {
+                                                error:
+                                                    (has_error || !!error_message) &&
+                                                    (name === 'stake' || name === 'max_stake'),
+                                            },
                                             { highlight: loss_threshold_warning_data?.highlight_field?.includes(name) }
                                         )}
                                         type={type}
                                         leading_icon={
                                             is_number ? (
                                                 <button
-                                                    disabled={disabled || (!!min && Number(field.value) === min)}
+                                                    disabled={
+                                                        disabled ||
+                                                        (!!min && Number(field.value) === min) ||
+                                                        (name === 'stake' &&
+                                                            Number(field.value) <=
+                                                                ((quick_strategy?.additional_data as any)?.min_stake ||
+                                                                    0.35)) ||
+                                                        Number(field.value) <= 1 // Disable minus button for all inputs when value is <= 1
+                                                    }
                                                     data-testid='qs-input-decrease'
                                                     onClick={(e: MouseEvent<HTMLButtonElement>) => {
-                                                        let value = Number(field.value) - 1;
-                                                        // Ensure the value doesn't go below the minimum
-                                                        if (!!min && value < min) {
-                                                            value = min;
+                                                        const min_stake =
+                                                            (quick_strategy?.additional_data as any)?.min_stake || 0.35;
+                                                        const current_value = Number(field.value);
+                                                        const field_min = name === 'stake' ? min_stake : min || 1;
+
+                                                        // For all fields
+                                                        // If value is greater than 1, subtract 1 from the value
+                                                        if (current_value > 1) {
+                                                            const new_value = current_value - 1;
+                                                            handleButtonInputChange(
+                                                                e,
+                                                                String(new_value % 1 ? new_value.toFixed(2) : new_value)
+                                                            );
+                                                            return;
                                                         }
-                                                        handleButtonInputChange(
-                                                            e,
-                                                            String(value % 1 ? value.toFixed(2) : value)
-                                                        );
+                                                        // If value is less than or equal to 1 but greater than minimum, set to minimum
+                                                        else if (current_value <= 1 && current_value > field_min) {
+                                                            handleButtonInputChange(e, String(field_min));
+                                                            return;
+                                                        }
+                                                        // If already at minimum, do nothing
+                                                        else if (current_value <= field_min) {
+                                                            return;
+                                                        }
                                                     }}
                                                 >
                                                     -
@@ -142,14 +247,44 @@ const QSInput: React.FC<TQSInput> = observer(
                                         {...field}
                                         disabled={disabled}
                                         onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleOnChange(e)}
+                                        onBlur={e => {
+                                            // Apply minimum value validation on blur for stake and max_stake fields
+                                            if (name === 'stake' || name === 'max_stake') {
+                                                const min_stake =
+                                                    (quick_strategy?.additional_data as any)?.min_stake || 0.35;
+                                                const value = e.target.value;
+
+                                                // If empty or less than minimum, set to minimum
+                                                if (
+                                                    value === '' ||
+                                                    value === '0' ||
+                                                    value === '0.' ||
+                                                    Number(value) < min_stake
+                                                ) {
+                                                    setFieldValue(name, min_stake);
+                                                    onChange(name, min_stake);
+                                                }
+                                            }
+                                        }}
                                         placeholder={is_exclusive_field ? '0.00' : ''}
                                         bottom_label={is_exclusive_field ? currency : ''}
                                         max_characters={2}
                                         maxLength={2}
-                                        inputMode={name === 'tick_count' ? 'numeric' : undefined}
-                                        pattern={name === 'tick_count' ? '[0-9]*' : undefined}
+                                        inputMode={
+                                            name === 'tick_count' ||
+                                            (name === 'duration' && quick_strategy.form_data?.durationtype === 't')
+                                                ? 'numeric'
+                                                : undefined
+                                        }
+                                        pattern={
+                                            name === 'tick_count' ||
+                                            (name === 'duration' && quick_strategy.form_data?.durationtype === 't')
+                                                ? '[0-9]*'
+                                                : undefined
+                                        }
                                         onKeyPress={
-                                            name === 'tick_count'
+                                            name === 'tick_count' ||
+                                            (name === 'duration' && quick_strategy.form_data?.durationtype === 't')
                                                 ? e => {
                                                       if (e.key === '.') {
                                                           e.preventDefault();
@@ -157,6 +292,37 @@ const QSInput: React.FC<TQSInput> = observer(
                                                   }
                                                 : undefined
                                         }
+                                        onKeyUp={e => {
+                                            // Check value on each keystroke for stake field
+                                            if (name === 'stake' || name === 'max_stake') {
+                                                const min_stake =
+                                                    (quick_strategy?.additional_data as any)?.min_stake || 0.35;
+                                                const max_stake =
+                                                    (quick_strategy?.additional_data as any)?.max_stake || 1000;
+                                                const value = e.currentTarget.value;
+
+                                                // Skip validation for empty or partial inputs
+                                                if (value === '' || value === '0' || value === '0.') {
+                                                    return;
+                                                }
+
+                                                const numValue = Number(value);
+
+                                                // Clear error message if value is valid
+                                                if (numValue >= min_stake && numValue <= max_stake) {
+                                                    setErrorMessage(null);
+                                                    return;
+                                                }
+
+                                                // Show error message if value is less than minimum stake or greater than maximum
+                                                if (numValue < min_stake) {
+                                                    setErrorMessage(`Minimum stake allowed is 0.35`);
+                                                } else if (numValue > max_stake) {
+                                                    // Allow entering any value but show error message for maximum
+                                                    setErrorMessage(`Maximum stake allowed is ${max_stake}`);
+                                                }
+                                            }
+                                        }}
                                     />
                                 </Popover>
                             </div>

--- a/src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx
+++ b/src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx
@@ -220,7 +220,7 @@ const QSInput: React.FC<TQSInput> = observer(
             if (input_value === '' || input_value === '0' || input_value === '0.') {
                 onChange(name, input_value);
 
-                // Show error message for empty values in stake and max_stake fields
+                // Show error message for empty values in fields
                 if (name === 'stake' || name === 'max_stake') {
                     const min_stake = (quick_strategy?.additional_data as any)?.min_stake || 0.35;
                     setErrorMessage(`Minimum stake allowed is ${min_stake}`);
@@ -318,7 +318,15 @@ const QSInput: React.FC<TQSInput> = observer(
                                 <Popover
                                     alignment='bottom'
                                     message={error || error_message} // Prioritize backend error over client-side error
-                                    is_open={!!(error || error_message) && (name === 'stake' || name === 'max_stake')} // Show error message for stake and max_stake fields
+                                    is_open={
+                                        !!(error || error_message) &&
+                                        (name === 'stake' ||
+                                            name === 'max_stake' ||
+                                            name === 'loss' ||
+                                            name === 'profit' ||
+                                            name === 'take_profit' ||
+                                            name === 'tick_count')
+                                    } // Show error message for all input fields that need validation
                                     zIndex='9999'
                                     classNameBubble='qs__warning-bubble'
                                     has_error
@@ -332,7 +340,12 @@ const QSInput: React.FC<TQSInput> = observer(
                                             {
                                                 error:
                                                     (has_error || !!error_message) &&
-                                                    (name === 'stake' || name === 'max_stake'),
+                                                    (name === 'stake' ||
+                                                        name === 'max_stake' ||
+                                                        name === 'loss' ||
+                                                        name === 'profit' ||
+                                                        name === 'take_profit' ||
+                                                        name === 'tick_count'),
                                             },
                                             { highlight: loss_threshold_warning_data?.highlight_field?.includes(name) }
                                         )}

--- a/src/pages/bot-builder/quick-strategy/selects/growth-rate-type.tsx
+++ b/src/pages/bot-builder/quick-strategy/selects/growth-rate-type.tsx
@@ -165,10 +165,10 @@ const GrowthRateSelect: React.FC<TContractTypes> = observer(({ name }) => {
                             `Minimum stake of ${min_stake} and maximum payout of ${max_payout}. Current payout is ${current_payout.toFixed(2)}.`
                         );
                     } else if (error_message.includes('Maximum stake allowed is')) {
-                        const max_stake = quick_strategy?.additional_data?.max_stake || '1000.00';
-                        error_message = localize(`Maximum stake allowed is ${max_stake}. Update your initial stake.`);
+                        const max_stake = quick_strategy?.additional_data?.max_stake || '1000';
+                        error_message = localize(`Maximum stake allowed is ${max_stake}`);
                     } else {
-                        error_message = `${error_response?.error?.message} ${localize('Update your initial stake.')}`;
+                        error_message = `${error_response?.error?.message}`;
                     }
 
                     // Set the error on the stake field instead of take_profit

--- a/src/pages/bot-builder/quick-strategy/types.ts
+++ b/src/pages/bot-builder/quick-strategy/types.ts
@@ -11,7 +11,7 @@ export type TFormData = {
     [key: string]: string | number | boolean;
 };
 
-export type TValidationType = 'min' | 'max' | 'required' | 'number' | 'ceil' | 'floor' | 'integer' | 'test';
+export type TValidationType = 'min' | 'max' | 'required' | 'number' | 'ceil' | 'floor' | 'integer';
 
 export interface ValidationObject {
     getMessage: (min: number | string) => string;

--- a/src/pages/bot-builder/quick-strategy/types.ts
+++ b/src/pages/bot-builder/quick-strategy/types.ts
@@ -11,18 +11,20 @@ export type TFormData = {
     [key: string]: string | number | boolean;
 };
 
-export type TValidationType = 'min' | 'max' | 'required' | 'number' | 'ceil' | 'floor' | 'integer';
+export type TValidationType = 'min' | 'max' | 'required' | 'number' | 'ceil' | 'floor' | 'integer' | 'test';
 
 export interface ValidationObject {
     getMessage: (min: number | string) => string;
     getDynamicValue?: (store: any) => number;
+    name?: string;
+    test?: (value: any, context: any) => boolean | string;
 }
 
 export type TValidationItem =
     | TValidationType
     | ({
           type: TValidationType;
-          value: number | string;
+          value?: number | string;
       } & ValidationObject);
 
 export type TStrategyDescription = {


### PR DESCRIPTION
This pull request includes several changes to the `quick-strategy` feature in the bot builder, focusing on input validation and error handling improvements. The most important changes include adding integer validation to the duration field, updating the input handling for stake and max_stake fields, and enhancing error message display logic.

Input validation improvements:

* [`src/pages/bot-builder/quick-strategy/config.ts`](diffhunk://#diff-69713ed61ab92a04940214bde8f1d48d6400960345e1ddd24e61a7618c63186eL190-R190): Added 'integer' to the validation array for the duration field to ensure only integer values are accepted.
* [`src/pages/bot-builder/quick-strategy/types.ts`](diffhunk://#diff-9e0f3ec8da20e27627e82113e3121399fedadd48b2e6c772dd4b44fd0dcc747bL14-R27): Added a new validation type 'test' and updated `ValidationObject` to include optional `name` and `test` properties.

Stake and max_stake input handling:

* [`src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx`](diffhunk://#diff-a5d6442de8ce7ac0e7af26611c486cceb1e7537c2a57284449af9a42f88802e2L38-R64): Implemented logic to ensure stake and max_stake values are within allowed ranges, and added client-side error messages for invalid values. [[1]](diffhunk://#diff-a5d6442de8ce7ac0e7af26611c486cceb1e7537c2a57284449af9a42f88802e2L38-R64) [[2]](diffhunk://#diff-a5d6442de8ce7ac0e7af26611c486cceb1e7537c2a57284449af9a42f88802e2R74-R139) [[3]](diffhunk://#diff-a5d6442de8ce7ac0e7af26611c486cceb1e7537c2a57284449af9a42f88802e2L85-R164)

Error message display enhancements:

* [`src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx`](diffhunk://#diff-a5d6442de8ce7ac0e7af26611c486cceb1e7537c2a57284449af9a42f88802e2L85-R164): Prioritized backend error messages over client-side errors and updated the popover to show error messages for stake and max_stake fields. [[1]](diffhunk://#diff-a5d6442de8ce7ac0e7af26611c486cceb1e7537c2a57284449af9a42f88802e2L85-R164) [[2]](diffhunk://#diff-a5d6442de8ce7ac0e7af26611c486cceb1e7537c2a57284449af9a42f88802e2L96-R219)
* [`src/pages/bot-builder/quick-strategy/selects/growth-rate-type.tsx`](diffhunk://#diff-2dadc92b761e0f8352aa0d3f0bc6c128b1a7b8556223523a66d06fcc5362a24bL168-R171): Simplified error messages for maximum stake validation.

Code cleanup:

* [`src/pages/bot-builder/quick-strategy/inputs/qs-input.tsx`](diffhunk://#diff-a5d6442de8ce7ac0e7af26611c486cceb1e7537c2a57284449af9a42f88802e2L8): Removed unused imports and refactored state management for better readability.