### PR TITLE
Moiz-BOT-2736-Remove dual notifications generation when importing from GDrive

### DIFF
--- a/src/external/bot-skeleton/scratch/utils/index.js
+++ b/src/external/bot-skeleton/scratch/utils/index.js
@@ -169,6 +169,9 @@ export const load = async ({
         if (xmlDoc.getElementsByTagName('parsererror').length) {
             return showInvalidStrategyError();
         }
+        else {
+            botNotification(notification_message().BOT_IMPORT);
+        }
     } catch (e) {
         return showInvalidStrategyError();
     }

--- a/src/stores/google-drive-store.ts
+++ b/src/stores/google-drive-store.ts
@@ -1,6 +1,6 @@
 import { action, makeObservable, observable } from 'mobx';
 import { botNotification } from '@/components/bot-notification/bot-notification';
-import { notification_message, NOTIFICATION_TYPE } from '@/components/bot-notification/bot-notification-utils';
+import { notification_message } from '@/components/bot-notification/bot-notification-utils';
 import { button_status } from '@/constants/button-status';
 import { config, importExternal } from '@/external/bot-skeleton';
 import { getInitialLanguage, localize } from '@deriv-com/translations';
@@ -305,7 +305,6 @@ export default class GoogleDriveStore {
                     const file_name = file.name;
                     const fileId = file.id;
                     const { files } = gapi.client.drive;
-                    const { setOpenSettings } = this.root_store.dashboard;
 
                     const response = await files.get({
                         alt: 'media',
@@ -313,7 +312,6 @@ export default class GoogleDriveStore {
                     });
 
                     resolve({ xml_doc: response.body, file_name });
-                   // setOpenSettings(NOTIFICATION_TYPE.BOT_IMPORT);
                     const upload_type = getStrategyType(response.body);
                     rudderStackSendUploadStrategyCompletedEvent({
                         upload_provider: 'google_drive',

--- a/src/stores/google-drive-store.ts
+++ b/src/stores/google-drive-store.ts
@@ -313,7 +313,7 @@ export default class GoogleDriveStore {
                     });
 
                     resolve({ xml_doc: response.body, file_name });
-                    setOpenSettings(NOTIFICATION_TYPE.BOT_IMPORT);
+                   // setOpenSettings(NOTIFICATION_TYPE.BOT_IMPORT);
                     const upload_type = getStrategyType(response.body);
                     rudderStackSendUploadStrategyCompletedEvent({
                         upload_provider: 'google_drive',


### PR DESCRIPTION
fix: removed notification from gdrive handler and added message to skeleton when parsing succeeds