### PR TITLE
Moiz-BOT-2742-Sync Deriv Bot Asset Display in Charting Functionality

### DIFF
--- a/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_market.js
+++ b/src/external/bot-skeleton/scratch/blocks/Binary/Trade Definition/trade_definition_market.js
@@ -1,7 +1,7 @@
 import { localize } from '@deriv-com/translations';
 import ApiHelpers from '../../../../services/api/api-helpers';
+import DBotStore from '../../../dbot-store';
 import { excludeOptionFromContextMenu, modifyContextMenu, runIrreversibleEvents } from '../../../utils';
-
 /* eslint-disable */
 window.Blockly.Blocks.trade_definition_market = {
     init() {
@@ -94,6 +94,9 @@ window.Blockly.Blocks.trade_definition_market = {
                     should_pretend_empty: true,
                     event_group: event.group,
                 });
+            } else if (event.name === 'SYMBOL_LIST') {
+                const new_symbol = symbol_dropdown.getValue();
+                DBotStore.instance.dashboard.setBotBuilderSymbol(new_symbol);
             }
         } else if (
             event.type === window.Blockly.Events.BLOCK_DRAG &&

--- a/src/stores/dashboard-store.ts
+++ b/src/stores/dashboard-store.ts
@@ -68,6 +68,7 @@ export default class DashboardStore implements IDashboardStore {
     core: TStores;
     tutorials_combined_content: (TFaqContent | TGuideContent | TUserGuideContent | TQuickStrategyContent)[] = [];
     combined_search: string[] = [];
+    bot_builder_symbol: string | null = null;
 
     constructor(root_store: RootStore, core: TStores) {
         makeObservable(this, {
@@ -119,6 +120,7 @@ export default class DashboardStore implements IDashboardStore {
             setShowMobileTourDialog: action.bound,
             is_chart_modal_visible: observable,
             is_trading_view_modal_visible: observable,
+            bot_builder_symbol: observable,
         });
         this.root_store = root_store;
         this.core = core;
@@ -262,6 +264,16 @@ export default class DashboardStore implements IDashboardStore {
         } = this.root_store;
         return is_dark_mode_on;
     }
+
+    setBotBuilderSymbol = (bot_builder_symbol: string | null) => {
+        this.bot_builder_symbol = bot_builder_symbol;
+
+        // Update chart symbol when bot builder symbol changes
+        const { chart_store } = this.root_store;
+        if (chart_store && bot_builder_symbol) {
+            chart_store.onSymbolChange(bot_builder_symbol);
+        }
+    };
 
     setShowMobileTourDialog = (show_mobile_tour_dialog: boolean) => {
         this.show_mobile_tour_dialog = show_mobile_tour_dialog;


### PR DESCRIPTION
fix: Synced symbol selection between bot builder and charts tab 