### PR TITLE
Rupato/fix: the invalid token handler

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { createBrowserRouter, createRoutesFromElements, Route, RouterProvider } from 'react-router-dom';
 import ChunkLoader from '@/components/loader/chunk-loader';
 import RoutePromptDialog from '@/components/route-prompt-dialog';
+import useInvalidTokenHandler from '@/hooks/useInvalidTokenHandler';
 import { StoreProvider } from '@/hooks/useStore';
 import CallbackPage from '@/pages/callback';
 import Endpoint from '@/pages/endpoint';
@@ -48,10 +49,17 @@ const router = createBrowserRouter(
 );
 
 function App() {
+    const { unregisterHandler } = useInvalidTokenHandler();
     React.useEffect(() => {
+        // Use the invalid token handler hook to automatically retrigger OIDC authentication
+        // when an invalid token is detected and the cookie logged state is true
+
         initSurvicate();
         window?.dataLayer?.push({ event: 'page_load' });
         return () => {
+            // Clean up the invalid token handler when the component unmounts
+            unregisterHandler?.();
+
             const survicate_box = document.getElementById('survicate-box');
             if (survicate_box) {
                 survicate_box.style.display = 'none';

--- a/src/hooks/useInvalidTokenHandler.ts
+++ b/src/hooks/useInvalidTokenHandler.ts
@@ -16,7 +16,6 @@ export const useInvalidTokenHandler = (): { unregisterHandler: () => void } => {
     const { retriggerOAuth2Login, isOAuth2Enabled } = useOauth2();
 
     const handleInvalidToken = () => {
-        console.log('Invalid token detected, retriggering OIDC authentication');
         if (isOAuth2Enabled) {
             retriggerOAuth2Login();
         }

--- a/src/hooks/useInvalidTokenHandler.ts
+++ b/src/hooks/useInvalidTokenHandler.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+import { observer as globalObserver } from '@/external/bot-skeleton/utils/observer';
+import { useOauth2 } from './auth/useOauth2';
+
+/**
+ * Hook to handle invalid token events by retriggering OIDC authentication
+ *
+ * This hook listens for 'InvalidToken' events emitted by the API base when
+ * a token is invalid but the cookie logged state is true. When such an event
+ * is detected, it automatically retriggers the OIDC authentication flow to
+ * get a new token.
+ *
+ * @returns {{ unregisterHandler: () => void }} An object containing a function to unregister the event handler
+ */
+export const useInvalidTokenHandler = (): { unregisterHandler: () => void } => {
+    const { retriggerOAuth2Login, isOAuth2Enabled } = useOauth2();
+
+    const handleInvalidToken = () => {
+        console.log('Invalid token detected, retriggering OIDC authentication');
+        if (isOAuth2Enabled) {
+            retriggerOAuth2Login();
+        }
+    };
+
+    // Subscribe to the InvalidToken event
+    useEffect(() => {
+        globalObserver.register('InvalidToken', handleInvalidToken);
+
+        // Cleanup the subscription when the component unmounts
+        return () => {
+            globalObserver.unregister('InvalidToken', handleInvalidToken);
+        };
+    }, [retriggerOAuth2Login, isOAuth2Enabled]);
+
+    // Return a function to unregister the handler manually if needed
+    return {
+        unregisterHandler: () => {
+            globalObserver.unregister('InvalidToken', handleInvalidToken);
+        },
+    };
+};
+
+export default useInvalidTokenHandler;

--- a/src/pages/callback/callback-page.tsx
+++ b/src/pages/callback/callback-page.tsx
@@ -1,4 +1,6 @@
+import Cookies from 'js-cookie';
 import { generateDerivApiInstance } from '@/external/bot-skeleton/services/api/appId';
+import { observer as globalObserver } from '@/external/bot-skeleton/utils/observer';
 import { Callback } from '@deriv-com/auth-client';
 import { Button } from '@deriv-com/ui';
 
@@ -36,9 +38,15 @@ const CallbackPage = () => {
                 const api = await generateDerivApiInstance();
                 if (api) {
                     const { authorize, error } = await api.authorize(tokens.token1);
-                    localStorage.setItem('callback_token', authorize.toString());
                     api.disconnect();
-                    if (!error) {
+                    if (error) {
+                        // Check if the error is due to an invalid token and if the logged_state cookie is true
+                        if (error.code === 'InvalidToken' && Cookies.get('logged_state') === 'true') {
+                            // Emit an event that can be caught by the application to retrigger OIDC authentication
+                            globalObserver.emit('InvalidToken', { error });
+                        }
+                    } else {
+                        localStorage.setItem('callback_token', authorize.toString());
                         const clientAccountsArray = Object.values(clientAccounts);
                         const firstId = authorize?.account_list[0]?.loginid;
                         const filteredTokens = clientAccountsArray.filter(account => account.loginid === firstId);


### PR DESCRIPTION
This pull request introduces a mechanism to handle invalid tokens by retriggering OIDC authentication when an invalid token is detected and the logged state cookie is true. The changes span multiple files and involve importing necessary modules, adding event listeners, and updating the logic to emit and handle the 'InvalidToken' event.

Key changes include:

### Token Handling and Authentication:

* [`src/app/App.tsx`](diffhunk://#diff-7c79023b16fd616788af0fdcb31d619ae04da7259aa564fd72fb0ea07d8ebe07R7): Integrated `useInvalidTokenHandler` hook to handle invalid tokens and ensure proper cleanup on component unmount. [[1]](diffhunk://#diff-7c79023b16fd616788af0fdcb31d619ae04da7259aa564fd72fb0ea07d8ebe07R7) [[2]](diffhunk://#diff-7c79023b16fd616788af0fdcb31d619ae04da7259aa564fd72fb0ea07d8ebe07R52-R62)
* [`src/app/AuthWrapper.tsx`](diffhunk://#diff-af63e738f04e9a6ee6aa4a007406f027572f6c9ba0d97b9dadc0f2e36d13521aR2-R5): Added logic to check for invalid tokens and emit an event to retrigger OIDC authentication if necessary. [[1]](diffhunk://#diff-af63e738f04e9a6ee6aa4a007406f027572f6c9ba0d97b9dadc0f2e36d13521aR2-R5) [[2]](diffhunk://#diff-af63e738f04e9a6ee6aa4a007406f027572f6c9ba0d97b9dadc0f2e36d13521aL31-R39)
* [`src/hooks/useInvalidTokenHandler.ts`](diffhunk://#diff-8605e1cbcded6bbc6ae855bc9989448fd87174d7b411203bee33a57b871e6618R1-R43): Created a custom hook to handle invalid token events by retriggering OIDC authentication.

### API Updates:

* [`src/external/bot-skeleton/services/api/api-base.ts`](diffhunk://#diff-3b0931891357dd6358fa53dcd1ab528d4de6ec5e344c41956adbe694df9e4c89R1): Updated the API base to emit an 'InvalidToken' event when an invalid token is detected. [[1]](diffhunk://#diff-3b0931891357dd6358fa53dcd1ab528d4de6ec5e344c41956adbe694df9e4c89R1) [[2]](diffhunk://#diff-3b0931891357dd6358fa53dcd1ab528d4de6ec5e344c41956adbe694df9e4c89L166-R175)
* [`src/external/bot-skeleton/services/api/chart-api.js`](diffhunk://#diff-ee46996129ef95e20f0222c7e4286fbf0e50b616b207768454403b9704e174daR1-R2): Added logic to the Chart API to handle invalid tokens and emit the appropriate event. [[1]](diffhunk://#diff-ee46996129ef95e20f0222c7e4286fbf0e50b616b207768454403b9704e174daR1-R2) [[2]](diffhunk://#diff-ee46996129ef95e20f0222c7e4286fbf0e50b616b207768454403b9704e174daL20-R30)

### OAuth2 Enhancements:

* [`src/hooks/auth/useOauth2.ts`](diffhunk://#diff-7ed7d4a03c35423f9e58a16d28f0b5af98eee2e3f4e729a311f562cd8b5d268bL5-R26): Enhanced the `useOauth2` hook to include a function for retriggering the OAuth2 login flow. [[1]](diffhunk://#diff-7ed7d4a03c35423f9e58a16d28f0b5af98eee2e3f4e729a311f562cd8b5d268bL5-R26) [[2]](diffhunk://#diff-7ed7d4a03c35423f9e58a16d28f0b5af98eee2e3f4e729a311f562cd8b5d268bL81-R103)

These changes ensure that the application can automatically handle invalid tokens by reinitiating the authentication process, thereby improving the user experience and maintaining secure access.