### PR TITLE
Moiz - BOT-2777 - On the initial load, when an asset is clicked, the selected asset is not highlighted in the dropdown list.

### DIFF
--- a/src/components/shared_ui/autocomplete/autocomplete.tsx
+++ b/src/components/shared_ui/autocomplete/autocomplete.tsx
@@ -174,6 +174,13 @@ const Autocomplete = React.memo((props: TAutocompleteProps) => {
         }
     }, [should_show_list, is_alignment_top, list_portal_id, filtered_items?.length]);
 
+    React.useEffect(() => {
+        if (value) {
+            const index = list_items.findIndex(item => (typeof item === 'object' ? item.text : item) === value);
+            setActiveIndex(index);
+        }
+    }, [value, list_items]);
+
     const handleScrollStop = (e: React.UIEvent<HTMLDivElement, UIEvent>) => {
         // pass onScrollStop func callback when scrolling stops
         if (!onScrollStop) return;
@@ -328,6 +335,12 @@ const Autocomplete = React.memo((props: TAutocompleteProps) => {
         }
         setFilteredItems(new_filtered_items);
     };
+
+    React.useEffect(() => {
+        console.log('Active Index', active_index);
+        console.log('Value Input', input_value);
+        console.log('Value Props', value);
+    }, [should_show_list, is_list_visible, value, input_value, active_index]);
 
     return (
         <div data-testid={data_testid} className={classNames('dc-autocomplete', className)}>

--- a/src/components/shared_ui/autocomplete/autocomplete.tsx
+++ b/src/components/shared_ui/autocomplete/autocomplete.tsx
@@ -336,11 +336,7 @@ const Autocomplete = React.memo((props: TAutocompleteProps) => {
         setFilteredItems(new_filtered_items);
     };
 
-    React.useEffect(() => {
-        console.log('Active Index', active_index);
-        console.log('Value Input', input_value);
-        console.log('Value Props', value);
-    }, [should_show_list, is_list_visible, value, input_value, active_index]);
+    React.useEffect(() => {}, [should_show_list, is_list_visible, value, input_value, active_index]);
 
     return (
         <div data-testid={data_testid} className={classNames('dc-autocomplete', className)}>

--- a/src/components/shared_ui/autocomplete/autocomplete.tsx
+++ b/src/components/shared_ui/autocomplete/autocomplete.tsx
@@ -336,8 +336,6 @@ const Autocomplete = React.memo((props: TAutocompleteProps) => {
         setFilteredItems(new_filtered_items);
     };
 
-    React.useEffect(() => {}, [should_show_list, is_list_visible, value, input_value, active_index]);
-
     return (
         <div data-testid={data_testid} className={classNames('dc-autocomplete', className)}>
             <div ref={input_wrapper_ref} className='dc-autocomplete__input-field'>


### PR DESCRIPTION
fix: added binding of active index based on value passed