### PR TITLE
Moiz-BOT-2789-Rise/fall trade type is not shown on run panel

### DIFF
--- a/src/constants/contract.ts
+++ b/src/constants/contract.ts
@@ -1,4 +1,5 @@
 import { getTotalProfit, TContractStore } from '@/components/shared';
+import { TContractOptions } from '@/components/shared';
 import { localize } from '@deriv-com/translations';
 
 export type TContract = {
@@ -44,7 +45,7 @@ type TSupportedContracts = {
     [key in TContractType]: TContract;
 };
 
-export const getSupportedContracts = (is_high_low: boolean): TSupportedContracts => ({
+export const getSupportedContracts = (is_high_low: TContractOptions): TSupportedContracts => ({
     ACCU: {
         name: localize('Accumulators'),
         position: 'top',
@@ -58,11 +59,11 @@ export const getSupportedContracts = (is_high_low: boolean): TSupportedContracts
         position: 'bottom',
     },
     CALL: {
-        name: is_high_low ? localize('Higher') : localize('Rise'),
+        name: is_high_low.isHighLow ? localize('Higher') : localize('Rise'),
         position: 'top',
     },
     PUT: {
-        name: is_high_low ? localize('Lower') : localize('Fall'),
+        name: is_high_low.isHighLow ? localize('Lower') : localize('Fall'),
         position: 'bottom',
     },
     CALLE: {


### PR DESCRIPTION
fix: updated type bindings