### PR TITLE
fix: dbot logout issue

### DIFF
--- a/src/hooks/useInvalidTokenHandler.ts
+++ b/src/hooks/useInvalidTokenHandler.ts
@@ -16,6 +16,12 @@ export const useInvalidTokenHandler = (): { unregisterHandler: () => void } => {
     const { retriggerOAuth2Login } = useOauth2();
 
     const handleInvalidToken = () => {
+        // Clear localStorage similar to client.logout
+        localStorage.removeItem('active_loginid');
+        localStorage.removeItem('accountsList');
+        localStorage.removeItem('authToken');
+        localStorage.removeItem('clientAccounts');
+
         retriggerOAuth2Login();
     };
 


### PR DESCRIPTION
This pull request updates the `useInvalidTokenHandler` hook to improve its handling of invalid tokens by ensuring local storage is cleared before retriggering the OAuth2 login.

Improvements to token handling:

* [`src/hooks/useInvalidTokenHandler.ts`](diffhunk://#diff-8605e1cbcded6bbc6ae855bc9989448fd87174d7b411203bee33a57b871e6618R19-R24): Added logic to clear specific items from `localStorage` (`active_loginid`, `accountsList`, `authToken`, and `clientAccounts`) in the `handleInvalidToken` function to ensure a clean state before calling `retriggerOAuth2Login`.