### PR TITLE
Rupato/fix  OIDC for dot com

### DIFF
--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -7,6 +7,7 @@ import { useOauth2 } from '@/hooks/auth/useOauth2';
 import useIsGrowthbookIsLoaded from '@/hooks/growthbook/useIsGrowthbookLoaded';
 import { useApiBase } from '@/hooks/useApiBase';
 import { useStore } from '@/hooks/useStore';
+import { isDotComSite } from '@/utils';
 import { StandaloneCircleUserRegularIcon } from '@deriv/quill-icons/Standalone';
 import { requestOidcAuthentication } from '@deriv-com/auth-client';
 import { Localize, useTranslations } from '@deriv-com/translations';
@@ -119,8 +120,7 @@ const AppHeader = observer(() => {
                             const query_param_currency =
                                 sessionStorage.getItem('query_param_currency') || currency || 'USD';
                             try {
-                                const is_com_site = /\.com$/i.test(window.location.hostname);
-                                if (is_com_site) {
+                                if (isDotComSite()) {
                                     await requestOidcAuthentication({
                                         redirectCallbackUri: `${window.location.origin}/callback`,
                                         ...(query_param_currency

--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -119,19 +119,22 @@ const AppHeader = observer(() => {
                             const query_param_currency =
                                 sessionStorage.getItem('query_param_currency') || currency || 'USD';
                             try {
-                                await requestOidcAuthentication({
-                                    redirectCallbackUri: `${window.location.origin}/callback`,
-                                    ...(query_param_currency
-                                        ? {
-                                              state: {
-                                                  account: query_param_currency,
-                                              },
-                                          }
-                                        : {}),
-                                }).catch(err => {
-                                    // eslint-disable-next-line no-console
-                                    console.error(err);
-                                });
+                                const is_com_site = /\.com$/i.test(window.location.hostname);
+                                if (is_com_site) {
+                                    await requestOidcAuthentication({
+                                        redirectCallbackUri: `${window.location.origin}/callback`,
+                                        ...(query_param_currency
+                                            ? {
+                                                  state: {
+                                                      account: query_param_currency,
+                                                  },
+                                              }
+                                            : {}),
+                                    }).catch(err => {
+                                        // eslint-disable-next-line no-console
+                                        console.error(err);
+                                    });
+                                }
                             } catch (error) {
                                 // eslint-disable-next-line no-console
                                 console.error(error);

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -121,10 +121,12 @@ const Layout = () => {
             sessionStorage.setItem('query_param_currency', currency);
         }
 
+        const is_com_site = /\.com$/i.test(window.location.hostname);
+
         const checkOIDCEnabledWithMissingAccount = !isEndpointPage && !isCallbackPage && !clientHasCurrency;
 
         if (
-            (isLoggedInCookie && !isClientAccountsPopulated && !isEndpointPage && !isCallbackPage) ||
+            (is_com_site && isLoggedInCookie && !isClientAccountsPopulated && !isEndpointPage && !isCallbackPage) ||
             checkOIDCEnabledWithMissingAccount
         ) {
             const query_param_currency = sessionStorage.getItem('query_param_currency') || currency || 'USD';

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -4,6 +4,7 @@ import Cookies from 'js-cookie';
 import { Outlet } from 'react-router-dom';
 import { api_base } from '@/external/bot-skeleton';
 import { useOauth2 } from '@/hooks/auth/useOauth2';
+import { isDotComSite } from '@/utils';
 import { requestOidcAuthentication } from '@deriv-com/auth-client';
 import { Loader, useDevice } from '@deriv-com/ui';
 import { crypto_currencies_display_order, fiat_currencies_display_order } from '../shared';
@@ -121,12 +122,10 @@ const Layout = () => {
             sessionStorage.setItem('query_param_currency', currency);
         }
 
-        const is_com_site = /\.com$/i.test(window.location.hostname);
-
         const checkOIDCEnabledWithMissingAccount = !isEndpointPage && !isCallbackPage && !clientHasCurrency;
 
         if (
-            (is_com_site && isLoggedInCookie && !isClientAccountsPopulated && !isEndpointPage && !isCallbackPage) ||
+            (isDotComSite() && isLoggedInCookie && !isClientAccountsPopulated && !isEndpointPage && !isCallbackPage) ||
             checkOIDCEnabledWithMissingAccount
         ) {
             const query_param_currency = sessionStorage.getItem('query_param_currency') || currency || 'USD';

--- a/src/hooks/auth/useOauth2.ts
+++ b/src/hooks/auth/useOauth2.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useEffect } from 'react';
 import Cookies from 'js-cookie';
 import RootStore from '@/stores/root-store';
+import { isDotComSite } from '@/utils';
 import { OAuth2Logout, requestOidcAuthentication } from '@deriv-com/auth-client';
 
 /**
@@ -72,9 +73,7 @@ export const useOauth2 = ({
     };
     const retriggerOAuth2Login = async () => {
         try {
-            const is_com_site = /\.com$/i.test(window.location.hostname);
-
-            if (is_com_site) {
+            if (isDotComSite()) {
                 await requestOidcAuthentication({
                     redirectCallbackUri: `${window.location.origin}/callback`,
                     postLogoutRedirectUri: window.location.origin,

--- a/src/hooks/auth/useOauth2.ts
+++ b/src/hooks/auth/useOauth2.ts
@@ -72,13 +72,17 @@ export const useOauth2 = ({
     };
     const retriggerOAuth2Login = async () => {
         try {
-            await requestOidcAuthentication({
-                redirectCallbackUri: `${window.location.origin}/callback`,
-                postLogoutRedirectUri: window.location.origin,
-            }).catch(err => {
-                // eslint-disable-next-line no-console
-                console.error('Error during OAuth2 login retrigger:', err);
-            });
+            const is_com_site = /\.com$/i.test(window.location.hostname);
+
+            if (is_com_site) {
+                await requestOidcAuthentication({
+                    redirectCallbackUri: `${window.location.origin}/callback`,
+                    postLogoutRedirectUri: window.location.origin,
+                }).catch(err => {
+                    // eslint-disable-next-line no-console
+                    console.error('Error during OAuth2 login retrigger:', err);
+                });
+            }
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error('Error during OAuth2 login retrigger:', error);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,11 @@
 export const print = (message: string) => {
     console.log(message); // eslint-disable-line no-console
 };
+
+/**
+ * Checks if the current site is a .com domain
+ * @returns {boolean} True if the site is a .com domain, false otherwise
+ */
+export const isDotComSite = (): boolean => {
+    return /\.com$/i.test(window.location.hostname);
+};


### PR DESCRIPTION
This pull request introduces a utility function, `isDotComSite`, to centralize the logic for determining if the current site is a `.com` domain. It then integrates this function into various components to conditionally handle OAuth2 authentication and related logic. Below are the key changes grouped by theme:

### New Utility Function

* Added a new function, `isDotComSite`, in `src/utils/index.ts` to check if the current site is a `.com` domain. This function uses a regular expression to test the hostname.

### Integration of `isDotComSite` in Components

* Updated `AppHeader` in `src/components/layout/header/header.tsx` to use `isDotComSite` for conditionally triggering `requestOidcAuthentication` during authentication flows. [[1]](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3R123) [[2]](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3R137)
* Modified `Layout` in `src/components/layout/index.tsx` to include `isDotComSite` in the conditional logic for handling OAuth2 login and account checks.

### Updates to `useOauth2` Hook

* Integrated `isDotComSite` into the `useOauth2` hook in `src/hooks/auth/useOauth2.ts` to ensure `requestOidcAuthentication` is triggered only for `.com` domains during OAuth2 login retriggers.

### Import Adjustments

* Added imports for `isDotComSite` in the relevant files: `src/components/layout/header/header.tsx`, `src/components/layout/index.tsx`, and `src/hooks/auth/useOauth2.ts`. [[1]](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3R10) [[2]](diffhunk://#diff-297411bbdb20a2ca96207a6e5284cd0598f90d22b776fa55232a04fae431835aR7) [[3]](diffhunk://#diff-7ed7d4a03c35423f9e58a16d28f0b5af98eee2e3f4e729a311f562cd8b5d268bR5)