### PR TITLE
fix: chart load issue

### DIFF
--- a/src/external/bot-skeleton/services/api/chart-api.js
+++ b/src/external/bot-skeleton/services/api/chart-api.js
@@ -26,6 +26,10 @@ class ChartAPI {
                     globalObserver.emit('InvalidToken', { error });
                 }
             } catch (e) {
+                localStorage.removeItem('active_loginid');
+                localStorage.removeItem('accountsList');
+                localStorage.removeItem('authToken');
+                localStorage.removeItem('clientAccounts');
                 console.error('Error authorizing chart API:', e);
             }
         }


### PR DESCRIPTION
This pull request includes a small but important change to the `ChartAPI` class in the `chart-api.js` file. The change ensures that specific local storage items are cleared when an error occurs during chart API authorization.

Key change:

* [`src/external/bot-skeleton/services/api/chart-api.js`](diffhunk://#diff-ee46996129ef95e20f0222c7e4286fbf0e50b616b207768454403b9704e174daR29-R32): Added removal of `active_loginid`, `accountsList`, `authToken`, and `clientAccounts` from local storage in the error-handling block of the `ChartAPI` class. This helps maintain a clean state in case of authorization errors.