### PR TITLE
fix: chart load issue

### DIFF
--- a/src/external/bot-skeleton/services/api/chart-api.js
+++ b/src/external/bot-skeleton/services/api/chart-api.js
@@ -1,6 +1,4 @@
-import Cookies from 'js-cookie';
-import { observer as globalObserver } from '../../utils/observer';
-import { generateDerivApiInstance, getLoginId, getToken } from './appId';
+import { generateDerivApiInstance } from './appId';
 
 class ChartAPI {
     api;
@@ -17,21 +15,6 @@ class ChartAPI {
             }
             this.api = await generateDerivApiInstance();
             this.api?.connection.addEventListener('close', this.onsocketclose.bind(this));
-        }
-        if (getLoginId()) {
-            try {
-                const { error } = await this.api.authorize(getToken().token);
-                if (error && error.code === 'InvalidToken' && Cookies.get('logged_state') === 'true') {
-                    // Emit an event that can be caught by the application to retrigger OIDC authentication
-                    globalObserver.emit('InvalidToken', { error });
-                }
-            } catch (e) {
-                localStorage.removeItem('active_loginid');
-                localStorage.removeItem('accountsList');
-                localStorage.removeItem('authToken');
-                localStorage.removeItem('clientAccounts');
-                console.error('Error authorizing chart API:', e);
-            }
         }
         this.getTime();
     };


### PR DESCRIPTION
This pull request simplifies the `ChartAPI` class by removing unused imports and the authorization logic, which appears to no longer be required. The changes focus on cleaning up the codebase and streamlining the initialization process for the `ChartAPI` class.

### Code cleanup:

* [`src/external/bot-skeleton/services/api/chart-api.js`](diffhunk://#diff-ee46996129ef95e20f0222c7e4286fbf0e50b616b207768454403b9704e174daL1-R1): Removed unused imports, including `Cookies`, `globalObserver`, `getLoginId`, and `getToken`, to reduce dependencies and improve maintainability.

### Simplification of `ChartAPI` initialization:

* [`src/external/bot-skeleton/services/api/chart-api.js`](diffhunk://#diff-ee46996129ef95e20f0222c7e4286fbf0e50b616b207768454403b9704e174daL21-L35): Removed the authorization logic, including the `authorize` call, error handling for invalid tokens, and cleanup of local storage. This simplifies the `initialize` method and eliminates reliance on token-based authentication in this class.