### PR TITLE
fix: chart load issue

### DIFF
--- a/src/app/AuthWrapper.tsx
+++ b/src/app/AuthWrapper.tsx
@@ -7,7 +7,11 @@ import { localize } from '@deriv-com/translations';
 import { URLUtils } from '@deriv-com/utils';
 import App from './App';
 
-const setLocalStorageToken = async (loginInfo: URLUtils.LoginInfo[], paramsToDelete: string[]) => {
+const setLocalStorageToken = async (
+    loginInfo: URLUtils.LoginInfo[],
+    paramsToDelete: string[],
+    setIsAuthComplete: React.Dispatch<React.SetStateAction<boolean>>
+) => {
     if (loginInfo.length) {
         try {
             const defaultActiveAccount = URLUtils.getDefaultActiveAccount(loginInfo);
@@ -31,10 +35,16 @@ const setLocalStorageToken = async (loginInfo: URLUtils.LoginInfo[], paramsToDel
                 const { authorize, error } = await api.authorize(loginInfo[0].token);
                 api.disconnect();
                 if (error) {
-                    // Check if the error is due to an invalid token and if the logged_state cookie is true
-                    if (error.code === 'InvalidToken' && Cookies.get('logged_state') === 'true') {
-                        // Emit an event that can be caught by the application to retrigger OIDC authentication
-                        globalObserver.emit('InvalidToken', { error });
+                    // Check if the error is due to an invalid token
+                    if (error.code === 'InvalidToken') {
+                        // Set isAuthComplete to true to prevent the app from getting stuck in loading state
+                        setIsAuthComplete(true);
+
+                        // Only emit the InvalidToken event if logged_state is true
+                        if (Cookies.get('logged_state') === 'true') {
+                            // Emit an event that can be caught by the application to retrigger OIDC authentication
+                            globalObserver.emit('InvalidToken', { error });
+                        }
                     }
                 } else {
                     const firstId = authorize?.account_list[0]?.loginid;
@@ -61,7 +71,7 @@ export const AuthWrapper = () => {
 
     React.useEffect(() => {
         const initializeAuth = async () => {
-            await setLocalStorageToken(loginInfo, paramsToDelete);
+            await setLocalStorageToken(loginInfo, paramsToDelete, setIsAuthComplete);
             URLUtils.filterSearchParams(['lang']);
             setIsAuthComplete(true);
         };

--- a/src/external/bot-skeleton/services/api/api-base.ts
+++ b/src/external/bot-skeleton/services/api/api-base.ts
@@ -165,12 +165,20 @@ class APIBase {
             try {
                 const { authorize, error } = await this.api.authorize(this.token);
                 if (error) {
-                    // Check if the error is due to an invalid token and if the logged_state cookie is true
-                    if (error.code === 'InvalidToken' && Cookies.get('logged_state') === 'true') {
-                        // Emit an event that can be caught by the application to retrigger OIDC authentication
-                        globalObserver.emit('InvalidToken', { error });
+                    // Check if the error is due to an invalid token
+                    if (error.code === 'InvalidToken') {
+                        // Make sure we set isAuthorizing to false before returning
+                        setIsAuthorizing(false);
+
+                        // Only emit the InvalidToken event if logged_state is true
+                        if (Cookies.get('logged_state') === 'true') {
+                            // Emit an event that can be caught by the application to retrigger OIDC authentication
+                            globalObserver.emit('InvalidToken', { error });
+                        }
                         return error;
                     }
+                    // Make sure we set isAuthorizing to false for other errors too
+                    setIsAuthorizing(false);
                     return error;
                 }
 

--- a/src/pages/callback/callback-page.tsx
+++ b/src/pages/callback/callback-page.tsx
@@ -40,10 +40,16 @@ const CallbackPage = () => {
                     const { authorize, error } = await api.authorize(tokens.token1);
                     api.disconnect();
                     if (error) {
-                        // Check if the error is due to an invalid token and if the logged_state cookie is true
-                        if (error.code === 'InvalidToken' && Cookies.get('logged_state') === 'true') {
-                            // Emit an event that can be caught by the application to retrigger OIDC authentication
-                            globalObserver.emit('InvalidToken', { error });
+                        // Check if the error is due to an invalid token
+                        if (error.code === 'InvalidToken') {
+                            // Set is_token_set to true to prevent the app from getting stuck in loading state
+                            is_token_set = true;
+
+                            // Only emit the InvalidToken event if logged_state is true
+                            if (Cookies.get('logged_state') === 'true') {
+                                // Emit an event that can be caught by the application to retrigger OIDC authentication
+                                globalObserver.emit('InvalidToken', { error });
+                            }
                         }
                     } else {
                         localStorage.setItem('callback_token', authorize.toString());


### PR DESCRIPTION
This pull request refines the handling of authentication errors across multiple files to improve user experience and prevent the app from getting stuck in a loading state. The changes primarily focus on ensuring proper state updates and conditional event emissions when invalid tokens are encountered.

### Updates to Authentication Error Handling:

* **`src/app/AuthWrapper.tsx`:**
  - Enhanced the `setLocalStorageToken` function to accept a `setIsAuthComplete` callback, ensuring the app updates its state (`isAuthComplete`) when an invalid token is detected. This prevents the app from remaining in a loading state. [[1]](diffhunk://#diff-af63e738f04e9a6ee6aa4a007406f027572f6c9ba0d97b9dadc0f2e36d13521aL10-R14) [[2]](diffhunk://#diff-af63e738f04e9a6ee6aa4a007406f027572f6c9ba0d97b9dadc0f2e36d13521aL34-R48)
  - Updated the `initializeAuth` function in the `AuthWrapper` component to pass the new `setIsAuthComplete` parameter to `setLocalStorageToken`.

* **`src/external/bot-skeleton/services/api/api-base.ts`:**
  - Adjusted the `APIBase` class to ensure `isAuthorizing` is set to `false` when an invalid token or other errors occur, preventing the app from hanging in an authorizing state.

* **`src/pages/callback/callback-page.tsx`:**
  - Modified the callback page logic to set `is_token_set` to `true` when an invalid token is detected, avoiding indefinite loading.