### PR TITLE
fix: unregisterHandler

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { createBrowserRouter, createRoutesFromElements, Route, RouterProvider } from 'react-router-dom';
 import ChunkLoader from '@/components/loader/chunk-loader';
 import RoutePromptDialog from '@/components/route-prompt-dialog';
-import useInvalidTokenHandler from '@/hooks/useInvalidTokenHandler';
 import { StoreProvider } from '@/hooks/useStore';
 import CallbackPage from '@/pages/callback';
 import Endpoint from '@/pages/endpoint';
@@ -49,7 +48,6 @@ const router = createBrowserRouter(
 );
 
 function App() {
-    const { unregisterHandler } = useInvalidTokenHandler();
     React.useEffect(() => {
         // Use the invalid token handler hook to automatically retrigger OIDC authentication
         // when an invalid token is detected and the cookie logged state is true
@@ -58,8 +56,6 @@ function App() {
         window?.dataLayer?.push({ event: 'page_load' });
         return () => {
             // Clean up the invalid token handler when the component unmounts
-            unregisterHandler?.();
-
             const survicate_box = document.getElementById('survicate-box');
             if (survicate_box) {
                 survicate_box.style.display = 'none';


### PR DESCRIPTION
This pull request removes the `useInvalidTokenHandler` hook from the `App` component in `src/app/App.tsx`, simplifying the component by eliminating unused functionality.

Code cleanup:

* [`src/app/App.tsx`](diffhunk://#diff-7c79023b16fd616788af0fdcb31d619ae04da7259aa564fd72fb0ea07d8ebe07L7): Removed the import for `useInvalidTokenHandler` and its associated code, including the `unregisterHandler` cleanup logic in the `App` component. This streamlines the component by removing unused code. [[1]](diffhunk://#diff-7c79023b16fd616788af0fdcb31d619ae04da7259aa564fd72fb0ea07d8ebe07L7) [[2]](diffhunk://#diff-7c79023b16fd616788af0fdcb31d619ae04da7259aa564fd72fb0ea07d8ebe07L52) [[3]](diffhunk://#diff-7c79023b16fd616788af0fdcb31d619ae04da7259aa564fd72fb0ea07d8ebe07L61-L62)