### PR TITLE
fix: invalid token

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,9 +3,9 @@ export const print = (message: string) => {
 };
 
 /**
- * Checks if the current site is a .com domain or localhost
- * @returns {boolean} True if the site is a .com domain or localhost, false otherwise
+ * Checks if the current site is a .com, .be, .me domain or localhost
+ * @returns {boolean} True if the site is a .com, .be, .me domain or localhost, false otherwise
  */
 export const isDotComSite = (): boolean => {
-    return /\.com$/i.test(window.location.hostname) || window.location.hostname === 'localhost';
+    return /\.(com|be|me)$/i.test(window.location.hostname) || window.location.hostname === 'localhost';
 };


### PR DESCRIPTION
This pull request introduces error-handling improvements in the API service and updates a utility function to expand domain validation. The most important changes are detailed below.

### Error-handling improvements in API service:
* Enhanced the error-handling logic in `APIBase` to wrap the existing error-checking code in a `try-catch` block. This ensures that any unexpected errors during error handling itself are caught, logged to the console, and handled gracefully by clearing authentication data and setting `isAuthorizing` to `false`. (`src/external/bot-skeleton/services/api/api-base.ts`, [src/external/bot-skeleton/services/api/api-base.tsL169-R187](diffhunk://#diff-3b0931891357dd6358fa53dcd1ab528d4de6ec5e344c41956adbe694df9e4c89L169-R187))

### Utility function update:
* Updated the `isDotComSite` utility function to include `.be` and `.me` domains in addition to `.com` and `localhost`. This broadens the scope of valid domains for the function. (`src/utils/index.ts`, [src/utils/index.tsL6-R10](diffhunk://#diff-6147e3c1761df71fd40952dbcbac388a45f80b8c318f367ef41048351a2c0c99L6-R10))