### PR TITLE
fix: deriv hub check

### DIFF
--- a/src/components/shared/utils/routes/routes.ts
+++ b/src/components/shared/utils/routes/routes.ts
@@ -1,4 +1,4 @@
-type Service = 'derivCom' | 'derivApp' | 'smartTrader';
+type Service = 'derivCom' | 'derivApp' | 'smartTrader' | 'derivHub';
 type DomainType = 'me' | 'be' | 'com';
 
 interface DomainConfig {
@@ -35,6 +35,14 @@ const domains: Record<Service, DomainConfig> = {
             com: 'https://smarttrader.deriv.com',
         },
     },
+    derivHub: {
+        staging: 'https://staging-hub.deriv.com',
+        production: {
+            me: 'https://hub.deriv.me',
+            be: 'https://hub.deriv.be',
+            com: 'https://hub.deriv.com',
+        },
+    },
 };
 
 const getDerivDomain = (service: Service): string => {
@@ -60,12 +68,12 @@ const getDerivDomain = (service: Service): string => {
  * Uses template literals to compose URLs dynamically.
  */
 export const standalone_routes = {
-    account_settings: `https://hub.deriv.com/tradershub/account`,
+    account_settings: `${getDerivDomain('derivHub')}/tradershub/account`,
     bot: `${window.location.origin}`,
     cashier: `${getDerivDomain('derivApp')}/cashier/`,
     cashier_deposit: `${getDerivDomain('derivApp')}/cashier/deposit`,
     cashier_p2p: `${getDerivDomain('derivApp')}/cashier/p2p`,
-    cfds: `https://hub.deriv.com/tradershub/cfds`,
+    cfds: `${getDerivDomain('derivHub')}/tradershub/cfds`,
     contract: `${getDerivDomain('derivApp')}/contract/:contract_id`,
     personal_details: `${getDerivDomain('derivApp')}/account/personal-details`,
     positions: `${getDerivDomain('derivApp')}/reports/positions`,
@@ -76,9 +84,9 @@ export const standalone_routes = {
     statement: `${getDerivDomain('derivApp')}/reports/statement`,
     trade: `${getDerivDomain('derivApp')}/dtrader`,
     traders_hub: getDerivDomain('derivApp'),
-    recent_transactions: `https://hub.deriv.com/tradershub/wallets/recent-transactions`,
+    recent_transactions: `${getDerivDomain('derivHub')}/tradershub/wallets/recent-transactions`,
     wallets_transfer: `${getDerivDomain('derivApp')}/wallet/account-transfer`,
-    signup: `https://hub.deriv.com/tradershub/signup`,
+    signup: `${getDerivDomain('derivHub')}/tradershub/signup`,
     deriv_com: getDerivDomain('derivCom'),
     deriv_app: getDerivDomain('derivApp'),
     endpoint: `${window.location.origin}/endpoint`,


### PR DESCRIPTION
This pull request introduces support for a new service, `derivHub`, by extending the `Service` type, updating domain configurations, and dynamically generating URLs for the new service. The changes improve modularity and maintainability by centralizing domain management and URL generation.

### Support for `derivHub` Service:

* **Added `derivHub` to the `Service` type**: The `Service` type now includes `derivHub` to represent the new service. (`[src/components/shared/utils/routes/routes.tsL1-R1](diffhunk://#diff-ae17cb6ca59eef476b8070e4acb7af4aa4beee209c84f7f87d1b4212f62a8a6aL1-R1)`)
* **Updated domain configurations**: Added staging and production domain URLs for `derivHub` in the `domains` object. (`[src/components/shared/utils/routes/routes.tsR38-R45](diffhunk://#diff-ae17cb6ca59eef476b8070e4acb7af4aa4beee209c84f7f87d1b4212f62a8a6aR38-R45)`)

### Dynamic URL Generation for `derivHub`:

* **Refactored URLs in `standalone_routes`**: Updated several URLs in `standalone_routes` to use `getDerivDomain('derivHub')` for dynamic domain resolution, improving flexibility and consistency. Affected routes include `account_settings`, `cfds`, `recent_transactions`, and `signup`. (`[[1]](diffhunk://#diff-ae17cb6ca59eef476b8070e4acb7af4aa4beee209c84f7f87d1b4212f62a8a6aL63-R76)`, `[[2]](diffhunk://#diff-ae17cb6ca59eef476b8070e4acb7af4aa4beee209c84f7f87d1b4212f62a8a6aL79-R89)`)