### PR TITLE
fix: dbot bug fixes

### DIFF
--- a/src/components/layout/header/account-switcher.tsx
+++ b/src/components/layout/header/account-switcher.tsx
@@ -77,7 +77,7 @@ const RenderAccountItems = ({
                 oAuthLogout={oAuthLogout}
                 loginid={activeLoginId}
                 is_logging_out={client.is_logging_out}
-                upgradeable_landing_companies={client.upgradeable_landing_companies ?? null}
+                upgradeable_landing_companies={client?.landing_companies?.all_company ?? null}
             />
         );
     }

--- a/src/components/layout/header/common/real-accounts.tsx
+++ b/src/components/layout/header/common/real-accounts.tsx
@@ -22,12 +22,11 @@ const RealAccounts = ({
     is_logging_out,
     upgradeable_landing_companies,
 }: TRealAccounts) => {
-    const upgradeable_landing_company_shortcode = upgradeable_landing_companies?.[0];
     const hasNonEuAccounts = modifiedCRAccountList && modifiedCRAccountList?.length > 0;
     const hasEuAccounts = modifiedMFAccountList && modifiedMFAccountList?.length > 0;
 
-    const getAccountTitle = (upgradeable_landing_company_shortcode: string) => {
-        switch (upgradeable_landing_company_shortcode) {
+    const getAccountTitle = (upgradeable_landing_companies: string) => {
+        switch (upgradeable_landing_companies) {
             case 'svg':
                 return localize('Options & Multipliers');
             case 'maltainvest':
@@ -60,19 +59,19 @@ const RealAccounts = ({
                     <AccountSwitcherDivider />
                 </>
             )}
-            {!hasNonEuAccounts && !hasEuAccounts && upgradeable_landing_company_shortcode && (
-                <div key={upgradeable_landing_company_shortcode} className='real-accounts__account-item'>
+            {!hasNonEuAccounts && !hasEuAccounts && upgradeable_landing_companies && (
+                <div key={upgradeable_landing_companies} className='real-accounts__account-item'>
                     <div className='real-accounts__account-item-left'>
                         <Icon icon='ic-deriv' className='deriv-account-switcher-item__icon' />
                         <span className='real-accounts__account-item-left-text'>
-                            {getAccountTitle(upgradeable_landing_company_shortcode ?? '')}
+                            {getAccountTitle(upgradeable_landing_companies ?? '')}
                         </span>
                     </div>
                     <button
                         className='add-button'
                         onClick={() => {
                             const baseUrl = getBaseTraderHubUrl();
-                            const redirectUrl = `${baseUrl}/tradershub/redirect?action=real-account-signup&target=${upgradeable_landing_company_shortcode}`;
+                            const redirectUrl = `${baseUrl}/tradershub/redirect?action=real-account-signup&target=${upgradeable_landing_companies}`;
                             window.location.href = redirectUrl;
                         }}
                     >

--- a/src/components/layout/header/common/types.tsx
+++ b/src/components/layout/header/common/types.tsx
@@ -51,7 +51,7 @@ export type TRealAccounts = TNoNonEuAccounts & {
     oAuthLogout: () => void;
     loginid?: string;
     is_logging_out: boolean;
-    upgradeable_landing_companies?: string[] | null;
+    upgradeable_landing_companies?: string | null;
 };
 export type TEuAccounts = TNoNonEuAccounts & {
     modifiedMFAccountList: TModifiedAccount[];

--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -4,6 +4,7 @@ import { standalone_routes } from '@/components/shared';
 import Button from '@/components/shared_ui/button';
 import useActiveAccount from '@/hooks/api/account/useActiveAccount';
 import { useOauth2 } from '@/hooks/auth/useOauth2';
+import useGrowthbookGetFeatureValue from '@/hooks/growthbook/useGrowthbookGetFeatureValue';
 import { useApiBase } from '@/hooks/useApiBase';
 import { useStore } from '@/hooks/useStore';
 import { StandaloneCircleUserRegularIcon } from '@deriv/quill-icons/Standalone';
@@ -33,6 +34,8 @@ const AppHeader = observer(() => {
     const { localize } = useTranslations();
 
     const { isSingleLoggingIn } = useOauth2();
+
+    const hub_enabled_country_list = useGrowthbookGetFeatureValue({ featureFlag: 'hub_enabled_country_list' });
 
     const renderAccountSection = () => {
         if (isAuthorizing || isSingleLoggingIn) {
@@ -77,8 +80,11 @@ const AppHeader = observer(() => {
                                 has_effect
                                 text={localize('Manage funds')}
                                 onClick={() => {
-                                    const redirect_url = new URL(standalone_routes.recent_transactions);
+                                    let redirect_url = new URL(standalone_routes.wallets_transfer);
 
+                                    if (hub_enabled_country_list) {
+                                        redirect_url = new URL(standalone_routes.recent_transactions);
+                                    }
                                     if (currency) {
                                         redirect_url.searchParams.set('account', currency);
                                     }

--- a/src/components/layout/header/menu-items/menu-items.tsx
+++ b/src/components/layout/header/menu-items/menu-items.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { observer } from 'mobx-react-lite';
-import { standalone_routes } from '@/components/shared';
-import useIsGrowthbookIsLoaded from '@/hooks/growthbook/useIsGrowthbookLoaded';
 import { useStore } from '@/hooks/useStore';
 import useStoreWalletAccountsList from '@/hooks/useStoreWalletAccountsList';
 import { handleTraderHubRedirect } from '@/utils/traders-hub-redirect';
@@ -53,6 +51,7 @@ export const MenuItems = observer(() => {
         return true;
     });
 
+    // TODO : need to add the skeleton loader when growthbook is not loaded
     return (
         <>
             {is_logged_in &&
@@ -87,7 +86,6 @@ export const MenuItems = observer(() => {
 export const TradershubLink = observer(() => {
     const { has_wallet = false } = useStoreWalletAccountsList() || {};
     const store = useStore();
-    const { isGBLoaded, isGBAvailable } = useIsGrowthbookIsLoaded();
 
     if (!store) return null;
 
@@ -106,23 +104,7 @@ export const TradershubLink = observer(() => {
 
     // If the redirect_url_str is null, use the default URL with appropriate parameters
     let href = redirect_url_str;
-    if (!href) {
-        let redirect_url = new URL(standalone_routes.wallets_transfer);
-
-        if (isGBAvailable && isGBLoaded) {
-            redirect_url = new URL(standalone_routes.recent_transactions);
-        }
-
-        if (is_virtual) {
-            // For demo accounts, set the account parameter to 'demo'
-            redirect_url.searchParams.set('account', 'demo');
-        } else if (currency) {
-            // For real accounts, set the account parameter to the currency
-            redirect_url.searchParams.set('account', currency);
-        }
-
-        href = redirect_url.toString();
-    } else if (redirect_url_str) {
+    if (redirect_url_str) {
         // If we have a redirect_url_str, we still need to add the account parameter
         try {
             const redirect_url = new URL(redirect_url_str);

--- a/src/components/shared/utils/routes/routes.ts
+++ b/src/components/shared/utils/routes/routes.ts
@@ -68,12 +68,11 @@ const getDerivDomain = (service: Service): string => {
  * Uses template literals to compose URLs dynamically.
  */
 export const standalone_routes = {
-    account_settings: `${getDerivDomain('derivHub')}/tradershub/account`,
+    account_settings: `${getDerivDomain('derivHub')}/accounts`,
     bot: `${window.location.origin}`,
     cashier: `${getDerivDomain('derivApp')}/cashier/`,
     cashier_deposit: `${getDerivDomain('derivApp')}/cashier/deposit`,
     cashier_p2p: `${getDerivDomain('derivApp')}/cashier/p2p`,
-    cfds: `${getDerivDomain('derivHub')}/tradershub/cfds`,
     contract: `${getDerivDomain('derivApp')}/contract/:contract_id`,
     personal_details: `${getDerivDomain('derivApp')}/account/personal-details`,
     positions: `${getDerivDomain('derivApp')}/reports/positions`,
@@ -84,7 +83,8 @@ export const standalone_routes = {
     statement: `${getDerivDomain('derivApp')}/reports/statement`,
     trade: `${getDerivDomain('derivApp')}/dtrader`,
     traders_hub: getDerivDomain('derivApp'),
-    recent_transactions: `${getDerivDomain('derivHub')}/tradershub/wallets/recent-transactions`,
+    traders_hub_lowcode: getDerivDomain('derivHub'),
+    recent_transactions: `${getDerivDomain('derivHub')}/tradershub/redirect?action=redirect_to&redirect_to=wallet`,
     wallets_transfer: `${getDerivDomain('derivApp')}/wallet/account-transfer`,
     signup: `${getDerivDomain('derivHub')}/tradershub/signup`,
     deriv_com: getDerivDomain('derivCom'),

--- a/src/utils/traders-hub-redirect.ts
+++ b/src/utils/traders-hub-redirect.ts
@@ -72,7 +72,7 @@ export const getWalletUrl = (): string => {
  */
 export const shouldRedirectToTraderHub = (has_wallet: boolean): boolean => {
     // Check if the country is in the enabled list from GrowthBook
-    const is_country_enabled = !!Analytics?.getFeatureValue('hub_enabled_country_list_bot', {});
+    const is_country_enabled = !!Analytics?.getFeatureValue('hub_enabled_country_list', {});
 
     // User should be redirected if they have wallets and their country is enabled
     return has_wallet && is_country_enabled;


### PR DESCRIPTION
This pull request includes updates to improve the handling of account-related logic, streamline routing, and integrate GrowthBook feature flags. The most important changes include modifying the `upgradeable_landing_companies` structure, updating route definitions, and refactoring GrowthBook usage for feature flag checks.

### Account-related Updates:
* Changed the structure of `upgradeable_landing_companies` from an array to a string in `TRealAccounts` and updated related logic in `real-accounts.tsx` and `account-switcher.tsx` to reflect this change. [[1]](diffhunk://#diff-bf3f2df057110808659b78456c70e733dec577bee954e3fc8391016c313164d1L80-R80) [[2]](diffhunk://#diff-4de4e43d901612b973866c07cad955bf91f25d95a235e111d1dcd15b39edcbeeL25-R29) [[3]](diffhunk://#diff-4de4e43d901612b973866c07cad955bf91f25d95a235e111d1dcd15b39edcbeeL63-R74) [[4]](diffhunk://#diff-174aad40a7c0d25bf564cf3237d9ce412154412b70c1a7e1beabc3e632ff73f0L54-R54)

### Routing Updates:
* Updated `standalone_routes` definitions, including changes to `account_settings` and `recent_transactions` routes, to align with new URL structures. [[1]](diffhunk://#diff-ae17cb6ca59eef476b8070e4acb7af4aa4beee209c84f7f87d1b4212f62a8a6aL71-L76) [[2]](diffhunk://#diff-ae17cb6ca59eef476b8070e4acb7af4aa4beee209c84f7f87d1b4212f62a8a6aL87-R87)

### GrowthBook Integration:
* Integrated `useGrowthbookGetFeatureValue` for feature flag checks in `header.tsx` and replaced `hub_enabled_country_list_bot` with `hub_enabled_country_list` in `traders-hub-redirect.ts`. [[1]](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3R7) [[2]](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3R38-R39) [[3]](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3L80-R87) [[4]](diffhunk://#diff-9e7ebbfc33380b8cdf202af9e5245d86a38c208dc40653c168d120e0d4dd8100L75-R75)

### Code Simplification:
* Removed unused GrowthBook-related logic from `menu-items.tsx` to simplify the codebase. [[1]](diffhunk://#diff-dc0c6cabb80e41effb7d5b0d9206c0bc3325309eb780758d24a71edb434360b5L3-L4) [[2]](diffhunk://#diff-dc0c6cabb80e41effb7d5b0d9206c0bc3325309eb780758d24a71edb434360b5L90) [[3]](diffhunk://#diff-dc0c6cabb80e41effb7d5b0d9206c0bc3325309eb780758d24a71edb434360b5L109-R107)