### PR TITLE
fix: translations

### DIFF
--- a/src/pages/tutorials/dbot-tours/common/tour-start-dialog.tsx
+++ b/src/pages/tutorials/dbot-tours/common/tour-start-dialog.tsx
@@ -54,13 +54,8 @@ const TourStartDialog = observer(() => {
                     <div>
                         <Localize
                             key={0}
-                            i18n_default_text={`Let's take a quick tour to discover how Deriv Bot works.<1 />Press <0>Start</0> to begin.`}
-                            components={[<strong key={0} />, <br key={1} />]}
-                        />
-                        <Localize
-                            key={0}
-                            i18n_default_text={`Hello World`}
-                            components={[<strong key={0} />, <br key={1} />]}
+                            i18n_default_text={`Let’s take a quick tour to discover how Deriv Bot works. Press <0>Start</0> to begin.`}
+                            components={[<strong key={0} />]}
                         />
                     </div>
                 ) : (


### PR DESCRIPTION
This pull request includes a minor update to the `TourStartDialog` component in the `src/pages/tutorials/dbot-tours/common/tour-start-dialog.tsx` file. The change simplifies the localized text displayed to users and removes an unused redundant localization block.

Changes to `TourStartDialog`:

* Simplified the `i18n_default_text` to remove the line break and redundant phrasing, making the message more concise.
* Removed an unused `Localize` block that contained a placeholder message (`Hello World`).