### PR TITLE
Fix  staging url

### DIFF
--- a/src/components/shared/utils/url/helpers.ts
+++ b/src/components/shared/utils/url/helpers.ts
@@ -20,8 +20,8 @@ export const getActionFromUrl = () => {
 
 export const getPlatformFromUrl = (domain = window.location.hostname) => {
     const resolutions = {
-        is_staging_deriv_app: /^staging-app\.deriv\.(com|me|be)$/i.test(domain),
-        is_deriv_app: /^app\.deriv\.(com|me|be)$/i.test(domain),
+        is_staging_deriv_app: /^staging-dbot\.deriv\.(com|me|be)$/i.test(domain),
+        is_deriv_app: /^dbot\.deriv\.(com|me|be)$/i.test(domain),
         is_test_link: /^(.*)\.binary\.sx$/i.test(domain),
         is_test_deriv_app: /^test-app\.deriv\.com$/i.test(domain),
     };

--- a/src/utils/traders-hub-redirect.ts
+++ b/src/utils/traders-hub-redirect.ts
@@ -1,6 +1,4 @@
 import { standalone_routes } from '@/components/shared';
-import { deriv_urls } from '@/components/shared/utils/url/constants';
-import { getPlatformFromUrl } from '@/components/shared/utils/url/helpers';
 import { Analytics } from '@deriv-com/analytics';
 
 /**
@@ -8,15 +6,19 @@ import { Analytics } from '@deriv-com/analytics';
  * @returns The base Trader's Hub URL
  */
 export const getBaseTraderHubUrl = (): string => {
-    const { is_staging_deriv_app, is_test_link, is_test_deriv_app } = getPlatformFromUrl();
-    // Get the domain from deriv_urls (e.g., deriv.com, deriv.me, deriv.be)
-    const domain = deriv_urls.DERIV_HOST_NAME;
+    const hostname = window.location.hostname;
 
-    // Determine if we're in a staging or testing environment
-    const is_staging_or_test = is_staging_deriv_app || is_test_link || is_test_deriv_app;
+    const domain = 'deriv.com';
 
-    // Construct the appropriate hub URL
-    return is_staging_or_test ? `https://staging-hub.${domain}` : `https://hub.${domain}`;
+    const is_staging = hostname.includes('staging');
+    const is_test =
+        hostname.includes('localhost') || hostname.includes('test') || /^\d+\.\d+\.\d+\.\d+$/.test(hostname);
+
+    if (is_staging || is_test) {
+        return `https://staging-hub.${domain}`;
+    }
+
+    return `https://hub.${domain}`;
 };
 
 /**


### PR DESCRIPTION
This pull request updates the logic for determining platform URLs and simplifies the `getBaseTraderHubUrl` function by removing dependencies on external constants and helper functions. The changes primarily focus on improving maintainability and aligning URL patterns with the application's requirements.

### Updates to URL handling:

* [`src/components/shared/utils/url/helpers.ts`](diffhunk://#diff-f94a2b43d9e9ace3e25aff62ca99c4b0840505637c5a2648fbfc041574cf991fL23-R24): Updated the regular expressions in `getPlatformFromUrl` to reflect the new URL patterns for `staging-dbot` and `dbot` subdomains instead of `staging-app` and `app`.

### Simplification of `getBaseTraderHubUrl`:

* [`src/utils/traders-hub-redirect.ts`](diffhunk://#diff-9e7ebbfc33380b8cdf202af9e5245d86a38c208dc40653c168d120e0d4dd8100L2-R21): Refactored `getBaseTraderHubUrl` to directly use `window.location.hostname` for determining the environment (staging, test, or production) and removed dependencies on `deriv_urls` and `getPlatformFromUrl`. This simplifies the function and improves clarity.