### PR TITLE
fix: removed the dotcom check

### DIFF
--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -12,7 +12,6 @@ import { requestOidcAuthentication } from '@deriv-com/auth-client';
 import { Localize, useTranslations } from '@deriv-com/translations';
 import { Header, useDevice, Wrapper } from '@deriv-com/ui';
 import { Tooltip } from '@deriv-com/ui';
-import { isDotComSite } from '../../../utils';
 import { AppLogo } from '../app-logo';
 import AccountsInfoLoader from './account-info-loader';
 import AccountSwitcher from './account-switcher';
@@ -122,21 +121,19 @@ const AppHeader = observer(() => {
                             const query_param_currency =
                                 sessionStorage.getItem('query_param_currency') || currency || 'USD';
                             try {
-                                if (isDotComSite()) {
-                                    await requestOidcAuthentication({
-                                        redirectCallbackUri: `${window.location.origin}/callback`,
-                                        ...(query_param_currency
-                                            ? {
-                                                  state: {
-                                                      account: query_param_currency,
-                                                  },
-                                              }
-                                            : {}),
-                                    }).catch(err => {
-                                        // eslint-disable-next-line no-console
-                                        console.error(err);
-                                    });
-                                }
+                                await requestOidcAuthentication({
+                                    redirectCallbackUri: `${window.location.origin}/callback`,
+                                    ...(query_param_currency
+                                        ? {
+                                              state: {
+                                                  account: query_param_currency,
+                                              },
+                                          }
+                                        : {}),
+                                }).catch(err => {
+                                    // eslint-disable-next-line no-console
+                                    console.error(err);
+                                });
                             } catch (error) {
                                 // eslint-disable-next-line no-console
                                 console.error(error);

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -5,7 +5,6 @@ import { Outlet } from 'react-router-dom';
 import { api_base } from '@/external/bot-skeleton';
 import { requestOidcAuthentication } from '@deriv-com/auth-client';
 import { useDevice } from '@deriv-com/ui';
-import { isDotComSite } from '../../utils';
 import { crypto_currencies_display_order, fiat_currencies_display_order } from '../shared';
 import Footer from './footer';
 import AppHeader from './header';
@@ -124,7 +123,7 @@ const Layout = () => {
         const checkOIDCEnabledWithMissingAccount = !isEndpointPage && !isCallbackPage && !clientHasCurrency;
 
         if (
-            (isDotComSite() && isLoggedInCookie && !isClientAccountsPopulated && !isEndpointPage && !isCallbackPage) ||
+            (isLoggedInCookie && !isClientAccountsPopulated && !isEndpointPage && !isCallbackPage) ||
             checkOIDCEnabledWithMissingAccount
         ) {
             const query_param_currency = sessionStorage.getItem('query_param_currency') || currency || 'USD';

--- a/src/hooks/auth/useOauth2.ts
+++ b/src/hooks/auth/useOauth2.ts
@@ -3,7 +3,6 @@ import { useEffect } from 'react';
 import Cookies from 'js-cookie';
 import RootStore from '@/stores/root-store';
 import { OAuth2Logout, requestOidcAuthentication } from '@deriv-com/auth-client';
-import { isDotComSite } from '../../utils';
 
 /**
  * Provides an object with properties: `oAuthLogout`, `retriggerOAuth2Login`, and `isSingleLoggingIn`.
@@ -73,15 +72,13 @@ export const useOauth2 = ({
     };
     const retriggerOAuth2Login = async () => {
         try {
-            if (isDotComSite()) {
-                await requestOidcAuthentication({
-                    redirectCallbackUri: `${window.location.origin}/callback`,
-                    postLogoutRedirectUri: window.location.origin,
-                }).catch(err => {
-                    // eslint-disable-next-line no-console
-                    console.error('Error during OAuth2 login retrigger:', err);
-                });
-            }
+            await requestOidcAuthentication({
+                redirectCallbackUri: `${window.location.origin}/callback`,
+                postLogoutRedirectUri: window.location.origin,
+            }).catch(err => {
+                // eslint-disable-next-line no-console
+                console.error('Error during OAuth2 login retrigger:', err);
+            });
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error('Error during OAuth2 login retrigger:', error);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,11 +1,3 @@
 export const print = (message: string) => {
     console.log(message); // eslint-disable-line no-console
 };
-
-/**
- * Checks if the current site is a .com, .be, .me domain or localhost
- * @returns {boolean} True if the site is a .com, .be, .me domain or localhost, false otherwise
- */
-export const isDotComSite = (): boolean => {
-    return /\.(com|be|me)$/i.test(window.location.hostname) || window.location.hostname === 'localhost';
-};


### PR DESCRIPTION
This pull request removes the `isDotComSite` utility function and its usage across the codebase, simplifying the logic for authentication and site checks. The most important changes include the removal of the `isDotComSite` function, updates to authentication logic in several components and hooks, and the cleanup of unused imports.

### Removal of `isDotComSite` function:
* [`src/utils/index.ts`](diffhunk://#diff-6147e3c1761df71fd40952dbcbac388a45f80b8c318f367ef41048351a2c0c99L4-L11): Deleted the `isDotComSite` function, which checked if the current site was a `.com`, `.be`, `.me` domain, or localhost.

### Updates to authentication logic:
* [`src/components/layout/header/header.tsx`](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3L15): Removed the conditional check for `isDotComSite` before calling `requestOidcAuthentication` in the `AppHeader` component. [[1]](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3L15) [[2]](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3L125) [[3]](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3L139)
* [`src/components/layout/index.tsx`](diffhunk://#diff-297411bbdb20a2ca96207a6e5284cd0598f90d22b776fa55232a04fae431835aL8): Simplified the authentication logic in the `Layout` component by removing the dependency on `isDotComSite`. [[1]](diffhunk://#diff-297411bbdb20a2ca96207a6e5284cd0598f90d22b776fa55232a04fae431835aL8) [[2]](diffhunk://#diff-297411bbdb20a2ca96207a6e5284cd0598f90d22b776fa55232a04fae431835aL127-R126)
* [`src/hooks/auth/useOauth2.ts`](diffhunk://#diff-7ed7d4a03c35423f9e58a16d28f0b5af98eee2e3f4e729a311f562cd8b5d268bL6): Removed the `isDotComSite` check from the `retriggerOAuth2Login` function in the `useOauth2` hook. [[1]](diffhunk://#diff-7ed7d4a03c35423f9e58a16d28f0b5af98eee2e3f4e729a311f562cd8b5d268bL6) [[2]](diffhunk://#diff-7ed7d4a03c35423f9e58a16d28f0b5af98eee2e3f4e729a311f562cd8b5d268bL76-L84)

### Cleanup of unused imports:
* Removed imports of `isDotComSite` from `src/components/layout/header/header.tsx`, `src/components/layout/index.tsx`, and `src/hooks/auth/useOauth2.ts` as they were no longer needed. [[1]](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3L15) [[2]](diffhunk://#diff-297411bbdb20a2ca96207a6e5284cd0598f90d22b776fa55232a04fae431835aL8) [[3]](diffhunk://#diff-7ed7d4a03c35423f9e58a16d28f0b5af98eee2e3f4e729a311f562cd8b5d268bL6)