### PR TITLE
fix: revert the redirection changes

### DIFF
--- a/src/components/layout/header/mobile-menu/use-mobile-menu-config.tsx
+++ b/src/components/layout/header/mobile-menu/use-mobile-menu-config.tsx
@@ -3,7 +3,6 @@ import Livechat from '@/components/chat/Livechat';
 import useIsLiveChatWidgetAvailable from '@/components/chat/useIsLiveChatWidgetAvailable';
 import { standalone_routes } from '@/components/shared';
 import { useOauth2 } from '@/hooks/auth/useOauth2';
-import useGrowthbookGetFeatureValue from '@/hooks/growthbook/useGrowthbookGetFeatureValue';
 import useRemoteConfig from '@/hooks/growthbook/useRemoteConfig';
 import { useIsIntercomAvailable } from '@/hooks/useIntercom';
 import useThemeSwitcher from '@/hooks/useThemeSwitcher';
@@ -58,9 +57,6 @@ const useMobileMenuConfig = (client?: RootStore['client']) => {
     const is_virtual = client?.is_virtual;
     const currency = client?.getCurrency?.();
     const is_logged_in = client?.is_logged_in;
-    const accounts = client?.accounts || {};
-
-    const { featureFlagValue } = useGrowthbookGetFeatureValue<any>({ featureFlag: 'hub_enabled_country_list' });
 
     // Function to add account parameter to URLs
     const getAccountUrl = (url: string) => {
@@ -87,18 +83,6 @@ const useMobileMenuConfig = (client?: RootStore['client']) => {
         }
     };
 
-    const has_wallet = Object.keys(accounts).some(id => accounts[id].account_category === 'wallet');
-    // Determine the appropriate redirect URL based on user's country
-    const getRedirectUrl = () => {
-        // Check if the user's country is in the hub-enabled country list
-        const is_hub_enabled_country = featureFlagValue?.hub_enabled_country_list?.includes(client?.residence);
-
-        if (has_wallet && is_hub_enabled_country) {
-            return getAccountUrl(standalone_routes.account_settings);
-        }
-        return getAccountUrl(standalone_routes.personal_details);
-    };
-
     const menuConfig = useMemo(
         (): TMenuConfig[] => [
             [
@@ -123,7 +107,7 @@ const useMobileMenuConfig = (client?: RootStore['client']) => {
                 },
                 {
                     as: 'a',
-                    href: getRedirectUrl(),
+                    href: getAccountUrl(standalone_routes.account_settings),
                     label: localize('Account Settings'),
                     LeftComponent: LegacyProfileSmIcon,
                 },


### PR DESCRIPTION
This pull request simplifies the `useMobileMenuConfig` hook in `src/components/layout/header/mobile-menu/use-mobile-menu-config.tsx` by removing unused imports and redundant logic related to feature flags and wallet accounts. It also updates the account settings URL logic to use a static route.

### Code cleanup and simplification:
* Removed the unused import `useGrowthbookGetFeatureValue` and its associated logic for retrieving feature flag values. [[1]](diffhunk://#diff-d1dbf017cbc6be00aadfd73ef141a2bfdf9f90b8464e96f24ae4f7870bdf6477L6) [[2]](diffhunk://#diff-d1dbf017cbc6be00aadfd73ef141a2bfdf9f90b8464e96f24ae4f7870bdf6477L61-L63)
* Deleted the `has_wallet` check and the `getRedirectUrl` function, which dynamically determined the redirect URL based on the user's country and wallet status.

### Static URL update:
* Updated the `href` property for the "Account Settings" menu item to use a static route (`standalone_routes.account_settings`) instead of relying on the removed `getRedirectUrl` function.