### PR TITLE
Rupato/fix: cashier link

### DIFF
--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -45,7 +45,14 @@ const AppHeader = observer(() => {
                     {/* <CustomNotifications /> */}
                     {isDesktop &&
                         (() => {
-                            const redirect_url = new URL(standalone_routes.account_settings);
+                            let redirect_url = new URL(standalone_routes.personal_details);
+                            const is_hub_enabled_country = featureFlagValue?.hub_enabled_country_list?.includes(
+                                client?.residence
+                            );
+
+                            if (has_wallet && is_hub_enabled_country) {
+                                redirect_url = new URL(standalone_routes.account_settings);
+                            }
                             // Check if the account is a demo account
                             // Use the URL parameter to determine if it's a demo account, as this will update when the account changes
                             const urlParams = new URLSearchParams(window.location.search);

--- a/src/components/layout/header/mobile-menu/use-mobile-menu-config.tsx
+++ b/src/components/layout/header/mobile-menu/use-mobile-menu-config.tsx
@@ -88,10 +88,10 @@ const useMobileMenuConfig = (client?: RootStore['client']) => {
     };
 
     const has_wallet = Object.keys(accounts).some(id => accounts[id].account_category === 'wallet');
+    const is_hub_enabled_country = featureFlagValue?.hub_enabled_country_list?.includes(client?.residence);
     // Determine the appropriate redirect URL based on user's country
     const getRedirectUrl = () => {
         // Check if the user's country is in the hub-enabled country list
-        const is_hub_enabled_country = featureFlagValue?.hub_enabled_country_list?.includes(client?.residence);
 
         if (has_wallet && is_hub_enabled_country) {
             return getAccountUrl(standalone_routes.account_settings);
@@ -127,12 +127,13 @@ const useMobileMenuConfig = (client?: RootStore['client']) => {
                     label: localize('Account Settings'),
                     LeftComponent: LegacyProfileSmIcon,
                 },
-                {
-                    as: 'a',
-                    href: standalone_routes.cashier_deposit,
-                    label: localize('Cashier'),
-                    LeftComponent: LegacyCashierIcon,
-                },
+                has_wallet &&
+                    is_hub_enabled_country && {
+                        as: 'a',
+                        href: standalone_routes.cashier_deposit,
+                        label: localize('Cashier'),
+                        LeftComponent: LegacyCashierIcon,
+                    },
                 client?.is_logged_in && {
                     as: 'button',
                     label: localize('Reports'),


### PR DESCRIPTION
This pull request introduces changes to the header and mobile menu components to improve the handling of redirect URLs and conditional menu items based on user account type and country-specific feature flags. The most important changes include adding logic to determine if a user's country is in a hub-enabled list and updating the behavior of redirects and menu configurations accordingly.

### Header Component Updates:
* Updated the `AppHeader` component to dynamically set the `redirect_url` based on whether the user has a wallet and resides in a hub-enabled country. This ensures that users in eligible countries are redirected to the appropriate settings page.

### Mobile Menu Updates:
* Refactored the `useMobileMenuConfig` hook to move the `is_hub_enabled_country` calculation outside of the `getRedirectUrl` function for better readability and reuse.
* Added a conditional check to include the "Cashier" menu item only if the user has a wallet and resides in a hub-enabled country, ensuring the menu is contextually relevant.