### PR TITLE
fix: cashier link

### DIFF
--- a/src/components/layout/header/mobile-menu/use-mobile-menu-config.tsx
+++ b/src/components/layout/header/mobile-menu/use-mobile-menu-config.tsx
@@ -127,8 +127,8 @@ const useMobileMenuConfig = (client?: RootStore['client']) => {
                     label: localize('Account Settings'),
                     LeftComponent: LegacyProfileSmIcon,
                 },
-                has_wallet &&
-                    is_hub_enabled_country && {
+                !has_wallet &&
+                    !is_hub_enabled_country && {
                         as: 'a',
                         href: standalone_routes.cashier_deposit,
                         label: localize('Cashier'),


### PR DESCRIPTION
This pull request modifies the behavior of the mobile menu configuration in `use-mobile-menu-config.tsx` to adjust the visibility of the "Cashier" menu item based on wallet and country hub settings.

### Changes to mobile menu behavior:

* [`src/components/layout/header/mobile-menu/use-mobile-menu-config.tsx`](diffhunk://#diff-d1dbf017cbc6be00aadfd73ef141a2bfdf9f90b8464e96f24ae4f7870bdf6477L130-R131): Updated the condition for displaying the "Cashier" menu item. The menu item is now shown when the user does **not** have a wallet and is **not** in a hub-enabled country, instead of the previous condition that required both to be true.