### PR TITLE
fix: removed trading assesment modal

### DIFF
--- a/src/app/app-root.tsx
+++ b/src/app/app-root.tsx
@@ -3,7 +3,6 @@ import { observer } from 'mobx-react-lite';
 import ErrorBoundary from '@/components/error-component/error-boundary';
 import ErrorComponent from '@/components/error-component/error-component';
 import ChunkLoader from '@/components/loader/chunk-loader';
-import TradingAssesmentModal from '@/components/trading-assesment-modal';
 import { api_base } from '@/external/bot-skeleton';
 import { useStore } from '@/hooks/useStore';
 import { localize } from '@deriv-com/translations';
@@ -64,7 +63,6 @@ const AppRoot = () => {
             <ErrorBoundary root_store={store}>
                 <ErrorComponentWrapper />
                 <AppContent />
-                <TradingAssesmentModal />
             </ErrorBoundary>
         </Suspense>
     );


### PR DESCRIPTION
This pull request removes the `TradingAssesmentModal` component from the `AppRoot` component in `src/app/app-root.tsx`. This change simplifies the structure of the application by eliminating an unused or unnecessary component.

### Component removal:

* [`src/app/app-root.tsx`](diffhunk://#diff-94879295562881d6d113d5d186e88ce8f3e5357139e22d4d8b73b250914133a8L6): Removed the import of `TradingAssesmentModal` and its usage within the `AppRoot` component. [[1]](diffhunk://#diff-94879295562881d6d113d5d186e88ce8f3e5357139e22d4d8b73b250914133a8L6) [[2]](diffhunk://#diff-94879295562881d6d113d5d186e88ce8f3e5357139e22d4d8b73b250914133a8L67)