### PR TITLE
fix: client residence check

### DIFF
--- a/src/components/layout/header/mobile-menu/use-mobile-menu-config.tsx
+++ b/src/components/layout/header/mobile-menu/use-mobile-menu-config.tsx
@@ -58,6 +58,7 @@ const useMobileMenuConfig = (client?: RootStore['client']) => {
     const is_virtual = client?.is_virtual;
     const currency = client?.getCurrency?.();
     const is_logged_in = client?.is_logged_in;
+    const client_residence = client?.residence;
     const accounts = client?.accounts || {};
 
     const { featureFlagValue } = useGrowthbookGetFeatureValue<any>({ featureFlag: 'hub_enabled_country_list' });
@@ -202,7 +203,7 @@ const useMobileMenuConfig = (client?: RootStore['client']) => {
                   ]
                 : [],
         ],
-        [is_virtual, currency, is_logged_in]
+        [is_virtual, currency, is_logged_in, client_residence]
     );
 
     return {


### PR DESCRIPTION
This pull request updates the `useMobileMenuConfig` hook in `src/components/layout/header/mobile-menu/use-mobile-menu-config.tsx` to include a new dependency and state value related to the client's residence. These changes ensure the hook accounts for the client's residence when determining the configuration.

### Updates to `useMobileMenuConfig`:

* Added `client_residence` to the list of extracted properties from the `client` object. (`[src/components/layout/header/mobile-menu/use-mobile-menu-config.tsxR61](diffhunk://#diff-d1dbf017cbc6be00aadfd73ef141a2bfdf9f90b8464e96f24ae4f7870bdf6477R61)`)
* Included `client_residence` in the dependency array for memoized values, ensuring the hook re-evaluates when the client's residence changes. (`[src/components/layout/header/mobile-menu/use-mobile-menu-config.tsxL205-R206](diffhunk://#diff-d1dbf017cbc6be00aadfd73ef141a2bfdf9f90b8464e96f24ae4f7870bdf6477L205-R206)`)