### PR TITLE
fix: added localstorage check

### DIFF
--- a/src/hooks/useTMB.ts
+++ b/src/hooks/useTMB.ts
@@ -58,7 +58,7 @@ const useTMB = (): UseTMBReturn => {
 
             const isEnabled = storedValue !== null ? storedValue === 'true' : !!result.dbot;
             // Update localStorage with the result so non-React components can access it
-
+            localStorage.setItem('is_tmb_enabled', isEnabled.toString());
             return isEnabled;
         } catch (e) {
             // eslint-disable-next-line no-console


### PR DESCRIPTION
This pull request includes a small change to the `useTMB` hook in `src/hooks/useTMB.ts`. The change ensures that the `is_tmb_enabled` value is stored in `localStorage` for consistent access across non-React components.