### PR TITLE
fix: remove localstorage value and use firebase config

### DIFF
--- a/src/app/AuthWrapper.tsx
+++ b/src/app/AuthWrapper.tsx
@@ -8,6 +8,13 @@ import { localize } from '@deriv-com/translations';
 import { URLUtils } from '@deriv-com/utils';
 import App from './App';
 
+// Extend Window interface to include is_tmb_enabled property
+declare global {
+    interface Window {
+        is_tmb_enabled?: boolean;
+    }
+}
+
 const setLocalStorageToken = async (
     loginInfo: URLUtils.LoginInfo[],
     paramsToDelete: string[],
@@ -41,7 +48,7 @@ const setLocalStorageToken = async (
                         // Set isAuthComplete to true to prevent the app from getting stuck in loading state
                         setIsAuthComplete(true);
 
-                        const is_tmb_enabled = localStorage.getItem('is_tmb_enabled') === 'true';
+                        const is_tmb_enabled = window.is_tmb_enabled === true;
                         // Only emit the InvalidToken event if logged_state is true
                         if (Cookies.get('logged_state') === 'true' && !is_tmb_enabled) {
                             // Emit an event that can be caught by the application to retrigger OIDC authentication

--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -38,7 +38,7 @@ const AppHeader = observer(() => {
 
     const { featureFlagValue } = useGrowthbookGetFeatureValue<any>({ featureFlag: 'hub_enabled_country_list' });
     const { onRenderTMBCheck } = useTMB();
-    const is_tmb_enabled = useMemo(() => JSON.parse(localStorage.getItem('is_tmb_enabled') || 'false'), []);
+    const is_tmb_enabled = useMemo(() => window.is_tmb_enabled === true, []);
 
     const renderAccountSection = () => {
         if (isAuthorizing || isSingleLoggingIn) {

--- a/src/external/bot-skeleton/services/api/api-base.ts
+++ b/src/external/bot-skeleton/services/api/api-base.ts
@@ -167,7 +167,7 @@ class APIBase {
             const { authorize, error } = await this.api.authorize(this.token);
             if (error) {
                 if (error.code === 'InvalidToken') {
-                    const is_tmb_enabled = JSON.parse(localStorage.getItem('is_tmb_enabled') || 'false');
+                    const is_tmb_enabled = window.is_tmb_enabled === true;
                     if (Cookies.get('logged_state') === 'true' && !is_tmb_enabled) {
                         globalObserver.emit('InvalidToken', { error });
                     } else {

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -88,7 +88,7 @@ export default class AppStore {
 
         // Check if we're in the process of logging in
         // When isSingleLoggingIn is true, we don't want to show the EU error message
-        const is_tmb_enabled = JSON.parse(localStorage.getItem('is_tmb_enabled') || 'false');
+        const is_tmb_enabled = window.is_tmb_enabled === true;
         const isSingleLoggingIn =
             window.location.pathname === '/callback' ||
             (Cookies.get('logged_state') === 'true' &&


### PR DESCRIPTION
This pull request refactors how the `is_tmb_enabled` flag is handled across the codebase. The flag, which was previously stored in `localStorage`, is now stored in the global `window` object. This change ensures consistent access to the flag across all components and simplifies its management. The most important changes include updating the logic for accessing `is_tmb_enabled`, modifying its initialization, and extending the `Window` interface.

### Refactoring the `is_tmb_enabled` flag:

* **Global storage for `is_tmb_enabled`:** The `is_tmb_enabled` flag has been moved from `localStorage` to the global `window` object. This change ensures all components access the flag consistently using `window.is_tmb_enabled`. (`[[1]](diffhunk://#diff-af63e738f04e9a6ee6aa4a007406f027572f6c9ba0d97b9dadc0f2e36d13521aL44-R51)`, `[[2]](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3L41-R41)`, `[[3]](diffhunk://#diff-3b0931891357dd6358fa53dcd1ab528d4de6ec5e344c41956adbe694df9e4c89L170-R170)`, `[[4]](diffhunk://#diff-2b2c12521ce90c2e7b4bd63888105bcd4112e69447589cd65eb23b4506000d57L91-R91)`)

* **Extending the `Window` interface:** The `Window` interface has been extended to include the optional `is_tmb_enabled` property. This ensures type safety when accessing the flag throughout the codebase. (`[[1]](diffhunk://#diff-af63e738f04e9a6ee6aa4a007406f027572f6c9ba0d97b9dadc0f2e36d13521aR11-R17)`, `[[2]](diffhunk://#diff-1693c842cbdff131e5a6d04a38e26e478527cfc01996cdc0d2ff41c37f551958R10-R16)`)

* **Initialization of `is_tmb_enabled`:** The logic for initializing `is_tmb_enabled` has been updated. Instead of relying on `localStorage`, the flag is now fetched from a remote configuration and stored directly in the `window` object. Fallback behavior has also been adjusted to default to `false` in case of errors. (`[src/hooks/useTMB.tsL47-R79](diffhunk://#diff-1693c842cbdff131e5a6d04a38e26e478527cfc01996cdc0d2ff41c37f551958L47-R79)`)