### PR TITLE
fix: local storage valuer

### DIFF
--- a/src/hooks/useTMB.ts
+++ b/src/hooks/useTMB.ts
@@ -65,7 +65,8 @@ const useTMB = (): UseTMBReturn => {
             const isEnabled = !!result.dbot;
 
             // Store in window object for all components to access
-            window.is_tmb_enabled = isEnabled;
+            const storedValue = localStorage.getItem('is_tmb_enabled');
+            window.is_tmb_enabled = storedValue ? JSON.parse(storedValue) : isEnabled;
 
             return isEnabled;
         } catch (e) {
@@ -75,7 +76,8 @@ const useTMB = (): UseTMBReturn => {
             const isEnabled = false;
 
             // Store in window object for all components to access
-            window.is_tmb_enabled = isEnabled;
+            const storedValue = localStorage.getItem('is_tmb_enabled');
+            window.is_tmb_enabled = storedValue ? JSON.parse(storedValue) : isEnabled;
 
             return isEnabled;
         }


### PR DESCRIPTION
This pull request modifies the `useTMB` hook in `src/hooks/useTMB.ts` to enhance how the `is_tmb_enabled` value is stored and accessed across components. The changes ensure that the value is first retrieved from `localStorage` (if available) before falling back to the computed value.

Key changes in `useTMB`:

* Updated the logic for setting `window.is_tmb_enabled` to prioritize retrieving the value from `localStorage`. If a stored value exists, it is parsed using `JSON.parse`; otherwise, the computed `isEnabled` value is used. [[1]](diffhunk://#diff-1693c842cbdff131e5a6d04a38e26e478527cfc01996cdc0d2ff41c37f551958L68-R69) [[2]](diffhunk://#diff-1693c842cbdff131e5a6d04a38e26e478527cfc01996cdc0d2ff41c37f551958L78-R80)