### PR TITLE
fix: check tmb consoles

### DIFF
--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -133,6 +133,8 @@ const AppHeader = observer(() => {
                             const currency = getQueryParams.get('account') ?? '';
                             const query_param_currency =
                                 currency || sessionStorage.getItem('query_param_currency') || 'USD';
+
+                            console.log('test log in query_param_currency', is_tmb_enabled);
                             try {
                                 if (is_tmb_enabled) {
                                     onRenderTMBCheck();

--- a/src/hooks/useTMB.ts
+++ b/src/hooks/useTMB.ts
@@ -64,9 +64,10 @@ const useTMB = (): UseTMBReturn => {
 
             const isEnabled = !!result.dbot;
 
-            // Store in window object for all components to access
+            // Always use the latest value from the API
             const storedValue = localStorage.getItem('is_tmb_enabled');
             window.is_tmb_enabled = storedValue ? JSON.parse(storedValue) : isEnabled;
+            console.log(`TMB is`, { result, window_is_tmb_enabled: window.is_tmb_enabled });
 
             return isEnabled;
         } catch (e) {
@@ -233,6 +234,15 @@ const useTMB = (): UseTMBReturn => {
         }
     }, [isCallbackPage, getActiveSessions, isEndpointPage, handleLogout, processTokens, domains, currentDomain]);
 
+    console.log('test is_tmb_enabled', {
+        is_tmb_enabled,
+        window_is_tmb_enabled: window.is_tmb_enabled,
+        isTmbEnabled: isTmbEnabled(),
+        isOAuth2Enabled,
+        isEndpointPage,
+        isCallbackPage,
+        currentDomain,
+    });
     return useMemo(
         () => ({
             handleLogout,


### PR DESCRIPTION
This pull request introduces several debug logs across the codebase to provide more visibility into the values of key variables related to TMB (Trading Management Bot) functionality. These logs are intended for debugging purposes and should be reviewed for potential removal or refinement before merging into production.

### Debugging Enhancements:

* [`src/components/layout/header/header.tsx`](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3R136-R137): Added a console log to display the value of `is_tmb_enabled` during the `query_param_currency` processing.

* `src/hooks/useTMB.ts`: 
  - Added a console log to show the `result` from the API and the value of `window.is_tmb_enabled` after parsing the stored value from `localStorage`.
  - Added a detailed console log to output the state of multiple variables (`is_tmb_enabled`, `window.is_tmb_enabled`, `isTmbEnabled()`, `isOAuth2Enabled`, `isEndpointPage`, `isCallbackPage`, and `currentDomain`) for debugging purposes.