### PR TITLE
Rupato/firebase update value

### DIFF
--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -134,7 +134,6 @@ const AppHeader = observer(() => {
                             const query_param_currency =
                                 currency || sessionStorage.getItem('query_param_currency') || 'USD';
 
-                            console.log('test log in query_param_currency', is_tmb_enabled);
                             try {
                                 if (is_tmb_enabled) {
                                     onRenderTMBCheck();

--- a/src/hooks/useTMB.ts
+++ b/src/hooks/useTMB.ts
@@ -56,6 +56,16 @@ const useTMB = (): UseTMBReturn => {
 
     const isTmbEnabled = useCallback(async () => {
         try {
+            // Check if we have a manually set value in localStorage
+            const storedValue = localStorage.getItem('is_tmb_enabled');
+
+            // If localStorage value is explicitly 'true', use that
+            if (storedValue === 'true') {
+                window.is_tmb_enabled = true;
+                return true;
+            }
+
+            // Otherwise, use the API value
             const url = is_staging
                 ? 'https://app-config-staging.firebaseio.com/remote_config/oauth/is_tmb_enabled.json'
                 : 'https://app-config-prod.firebaseio.com/remote_config/oauth/is_tmb_enabled.json';
@@ -64,23 +74,27 @@ const useTMB = (): UseTMBReturn => {
 
             const isEnabled = !!result.dbot;
 
-            // Always use the latest value from the API
-            const storedValue = localStorage.getItem('is_tmb_enabled');
-            window.is_tmb_enabled = storedValue ? JSON.parse(storedValue) : isEnabled;
+            // Update window property with API value
+            window.is_tmb_enabled = isEnabled;
             console.log(`TMB is`, { result, window_is_tmb_enabled: window.is_tmb_enabled });
 
             return isEnabled;
         } catch (e) {
             // eslint-disable-next-line no-console
             console.error(e);
-            // by default it will fallback to false if firebase error happens
-            const isEnabled = false;
 
-            // Store in window object for all components to access
+            // Check if we have a manually set value in localStorage
             const storedValue = localStorage.getItem('is_tmb_enabled');
-            window.is_tmb_enabled = storedValue ? JSON.parse(storedValue) : isEnabled;
 
-            return isEnabled;
+            // If localStorage value is explicitly 'true', use that
+            if (storedValue === 'true') {
+                window.is_tmb_enabled = true;
+                return true;
+            }
+
+            // By default it will fallback to false if firebase error happens
+            window.is_tmb_enabled = false;
+            return false;
         }
     }, [is_staging]);
 

--- a/src/hooks/useTMB.ts
+++ b/src/hooks/useTMB.ts
@@ -76,8 +76,6 @@ const useTMB = (): UseTMBReturn => {
 
             // Update window property with API value
             window.is_tmb_enabled = isEnabled;
-            console.log(`TMB is`, { result, window_is_tmb_enabled: window.is_tmb_enabled });
-
             return isEnabled;
         } catch (e) {
             // eslint-disable-next-line no-console
@@ -248,15 +246,6 @@ const useTMB = (): UseTMBReturn => {
         }
     }, [isCallbackPage, getActiveSessions, isEndpointPage, handleLogout, processTokens, domains, currentDomain]);
 
-    console.log('test is_tmb_enabled', {
-        is_tmb_enabled,
-        window_is_tmb_enabled: window.is_tmb_enabled,
-        isTmbEnabled: isTmbEnabled(),
-        isOAuth2Enabled,
-        isEndpointPage,
-        isCallbackPage,
-        currentDomain,
-    });
     return useMemo(
         () => ({
             handleLogout,


### PR DESCRIPTION
This pull request refines the handling of the `is_tmb_enabled` flag and removes unnecessary logging for cleaner code. The changes improve how the application determines and stores the `is_tmb_enabled` state, prioritizing manually set values from `localStorage` while ensuring fallback mechanisms are in place.

### Improvements to `is_tmb_enabled` handling:

* [`src/hooks/useTMB.ts`](diffhunk://#diff-1693c842cbdff131e5a6d04a38e26e478527cfc01996cdc0d2ff41c37f551958R59-R68): Added logic to prioritize manually set values in `localStorage` for `is_tmb_enabled`. If the stored value is explicitly `'true'`, it overrides the API value. Updated fallback behavior to default to `false` in case of API errors. [[1]](diffhunk://#diff-1693c842cbdff131e5a6d04a38e26e478527cfc01996cdc0d2ff41c37f551958R59-R68) [[2]](diffhunk://#diff-1693c842cbdff131e5a6d04a38e26e478527cfc01996cdc0d2ff41c37f551958L67-R95)

### Code cleanup:

* [`src/hooks/useTMB.ts`](diffhunk://#diff-1693c842cbdff131e5a6d04a38e26e478527cfc01996cdc0d2ff41c37f551958L237-L245): Removed redundant logging statements related to `is_tmb_enabled` to streamline the code.
* [`src/components/layout/header/header.tsx`](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3L137): Removed a test log statement from the `query_param_currency` logic.