### PR TITLE
Rupato/fix  app root loading state

### DIFF
--- a/src/app/app-root.tsx
+++ b/src/app/app-root.tsx
@@ -5,6 +5,7 @@ import ErrorComponent from '@/components/error-component/error-component';
 import ChunkLoader from '@/components/loader/chunk-loader';
 import { api_base } from '@/external/bot-skeleton';
 import { useStore } from '@/hooks/useStore';
+import useTMB from '@/hooks/useTMB';
 import { localize } from '@deriv-com/translations';
 import './app-root.scss';
 
@@ -37,6 +38,8 @@ const AppRoot = () => {
     const store = useStore();
     const api_base_initialized = useRef(false);
     const [is_api_initialized, setIsApiInitialized] = useState(false);
+    const { isTmbEnabled } = useTMB();
+    const is_tmb_enabled = isTmbEnabled() || window.is_tmb_enabled === true;
 
     useEffect(() => {
         const initializeApi = async () => {
@@ -54,9 +57,9 @@ const AppRoot = () => {
         };
 
         initializeApi();
-    }, []);
+    }, [is_tmb_enabled]);
 
-    if (!store || !is_api_initialized) return <AppRootLoader />;
+    if (!store || (!is_api_initialized && !is_tmb_enabled)) return <AppRootLoader />;
 
     return (
         <Suspense fallback={<AppRootLoader />}>

--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import clsx from 'clsx';
 import { observer } from 'mobx-react-lite';
 import { standalone_routes } from '@/components/shared';
@@ -37,8 +38,9 @@ const AppHeader = observer(() => {
 
     const { featureFlagValue } = useGrowthbookGetFeatureValue<any>({ featureFlag: 'hub_enabled_country_list' });
     const { onRenderTMBCheck, isTmbEnabled } = useTMB();
+    const is_tmb_enabled = isTmbEnabled() || window.is_tmb_enabled === true;
 
-    const renderAccountSection = () => {
+    const renderAccountSection = useCallback(() => {
         if (isAuthorizing || isSingleLoggingIn) {
             return <AccountsInfoLoader isLoggedIn isMobile={!isDesktop} speed={3} />;
         } else if (activeLoginid) {
@@ -174,7 +176,22 @@ const AppHeader = observer(() => {
                 </div>
             );
         }
-    };
+    }, [
+        isAuthorizing,
+        isSingleLoggingIn,
+        isDesktop,
+        activeLoginid,
+        standalone_routes,
+        featureFlagValue,
+        client,
+        has_wallet,
+        currency,
+        localize,
+        activeAccount,
+        is_virtual,
+        onRenderTMBCheck,
+        is_tmb_enabled,
+    ]);
 
     if (client?.should_hide_header) return null;
 

--- a/src/components/layout/header/mobile-menu/use-mobile-menu-config.tsx
+++ b/src/components/layout/header/mobile-menu/use-mobile-menu-config.tsx
@@ -7,6 +7,7 @@ import useGrowthbookGetFeatureValue from '@/hooks/growthbook/useGrowthbookGetFea
 import useRemoteConfig from '@/hooks/growthbook/useRemoteConfig';
 import { useIsIntercomAvailable } from '@/hooks/useIntercom';
 import useThemeSwitcher from '@/hooks/useThemeSwitcher';
+import useTMB from '@/hooks/useTMB';
 import RootStore from '@/stores/root-store';
 import {
     LegacyAccountLimitsIcon,
@@ -60,6 +61,8 @@ const useMobileMenuConfig = (client?: RootStore['client']) => {
     const is_logged_in = client?.is_logged_in;
     const client_residence = client?.residence;
     const accounts = client?.accounts || {};
+    const { isTmbEnabled } = useTMB();
+    const is_tmb_enabled = window.is_tmb_enabled || isTmbEnabled();
 
     const { featureFlagValue } = useGrowthbookGetFeatureValue<any>({ featureFlag: 'hub_enabled_country_list' });
 
@@ -199,7 +202,7 @@ const useMobileMenuConfig = (client?: RootStore['client']) => {
                   ]
                 : [],
         ],
-        [is_virtual, currency, is_logged_in, client_residence]
+        [is_virtual, currency, is_logged_in, client_residence, is_tmb_enabled]
     );
 
     return {


### PR DESCRIPTION
This pull request introduces changes to integrate the `useTMB` hook across multiple components and improve their behavior based on the `is_tmb_enabled` flag. The updates ensure that components dynamically adjust their logic depending on the TMB feature's availability. Key changes include the addition of the `useTMB` hook, modifications to conditional rendering, and dependencies in React hooks.

### Integration of `useTMB` Hook:

* **`src/app/app-root.tsx`**: Added the `useTMB` hook and introduced the `is_tmb_enabled` flag, which combines the hook's output with a global window variable. Updated the `useEffect` dependency array and conditional rendering logic to account for `is_tmb_enabled`. [[1]](diffhunk://#diff-94879295562881d6d113d5d186e88ce8f3e5357139e22d4d8b73b250914133a8R8) [[2]](diffhunk://#diff-94879295562881d6d113d5d186e88ce8f3e5357139e22d4d8b73b250914133a8R41-R42) [[3]](diffhunk://#diff-94879295562881d6d113d5d186e88ce8f3e5357139e22d4d8b73b250914133a8L57-R62)

* **`src/components/layout/header/header.tsx`**: Integrated the `useTMB` hook and added the `is_tmb_enabled` flag. Refactored the `renderAccountSection` function to use `useCallback`, including `is_tmb_enabled` in its dependency array for memoization. [[1]](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3R1) [[2]](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3R41-R43) [[3]](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3L177-R194)

* **`src/components/layout/header/mobile-menu/use-mobile-menu-config.tsx`**: Added the `useTMB` hook and incorporated the `is_tmb_enabled` flag into the configuration logic. Updated dependencies for memoized values to include `is_tmb_enabled`. [[1]](diffhunk://#diff-d1dbf017cbc6be00aadfd73ef141a2bfdf9f90b8464e96f24ae4f7870bdf6477R10) [[2]](diffhunk://#diff-d1dbf017cbc6be00aadfd73ef141a2bfdf9f90b8464e96f24ae4f7870bdf6477R64-R65) [[3]](diffhunk://#diff-d1dbf017cbc6be00aadfd73ef141a2bfdf9f90b8464e96f24ae4f7870bdf6477L202-R205)