### PR TITLE
fix: account switcher currency names

### DIFF
--- a/src/app/CoreStoreProvider.tsx
+++ b/src/app/CoreStoreProvider.tsx
@@ -8,6 +8,7 @@ import { api_base } from '@/external/bot-skeleton';
 import { useOauth2 } from '@/hooks/auth/useOauth2';
 import { useApiBase } from '@/hooks/useApiBase';
 import { useStore } from '@/hooks/useStore';
+import useTMB from '@/hooks/useTMB';
 import { TLandingCompany, TSocketResponseData } from '@/types/api-types';
 import { useTranslations } from '@deriv-com/translations';
 
@@ -24,7 +25,14 @@ const CoreStoreProvider: React.FC<{ children: React.ReactNode }> = observer(({ c
 
     const { oAuthLogout } = useOauth2({ handleLogout: async () => client.logout(), client });
 
-    const isLoggedOutCookie = Cookies.get('logged_state') === 'false';
+    const { is_tmb_enabled: tmb_enabled_from_hook } = useTMB();
+
+    const is_tmb_enabled = useMemo(
+        () => window.is_tmb_enabled === true || tmb_enabled_from_hook,
+        [tmb_enabled_from_hook]
+    );
+
+    const isLoggedOutCookie = Cookies.get('logged_state') === 'false' && !is_tmb_enabled;
 
     useEffect(() => {
         if (isLoggedOutCookie && client?.is_logged_in) {


### PR DESCRIPTION
This pull request introduces a new hook, `useTMB`, to enhance the functionality of the `CoreStoreProvider` component. The most important changes involve integrating this hook to determine the `is_tmb_enabled` state and updating the logic for handling the `isLoggedOutCookie` condition.

### Integration of `useTMB` hook:
* [`src/app/CoreStoreProvider.tsx`](diffhunk://#diff-5ec7969cf78888b570b3224805b4252b136ff69101053e09e361de4be5cdded8R11): Added import for `useTMB` to utilize its functionality within the `CoreStoreProvider` component.
* [`src/app/CoreStoreProvider.tsx`](diffhunk://#diff-5ec7969cf78888b570b3224805b4252b136ff69101053e09e361de4be5cdded8L27-R35): Introduced a new `is_tmb_enabled` state using `useTMB` and `useMemo` to combine the hook's output with a global `window.is_tmb_enabled` flag. This state is used to refine the logic for determining whether the user is logged out.