### PR TITLE
fix: localstorage check for tmb

### DIFF
--- a/src/hooks/useTMB.ts
+++ b/src/hooks/useTMB.ts
@@ -115,12 +115,17 @@ const useTMB = (): UseTMBReturn => {
                 // Check if we have a manually set value in localStorage
                 const storedValue = localStorage.getItem('is_tmb_enabled');
 
-                // If localStorage value is explicitly 'true', use that
+                // If localStorage value is explicitly set, use that value
                 if (storedValue === 'true') {
                     window.is_tmb_enabled = true;
                     setIsTmbEnabled(true);
                     tmbStatusDeterminedRef.current = true;
                     return true;
+                } else if (storedValue === 'false') {
+                    window.is_tmb_enabled = false;
+                    setIsTmbEnabled(false);
+                    tmbStatusDeterminedRef.current = true;
+                    return false;
                 }
 
                 // Otherwise, use the API value
@@ -144,12 +149,17 @@ const useTMB = (): UseTMBReturn => {
                 // Check if we have a manually set value in localStorage
                 const storedValue = localStorage.getItem('is_tmb_enabled');
 
-                // If localStorage value is explicitly 'true', use that
+                // If localStorage value is explicitly set, use that value
                 if (storedValue === 'true') {
                     window.is_tmb_enabled = true;
                     setIsTmbEnabled(true);
                     tmbStatusDeterminedRef.current = true;
                     return true;
+                } else if (storedValue === 'false') {
+                    window.is_tmb_enabled = false;
+                    setIsTmbEnabled(false);
+                    tmbStatusDeterminedRef.current = true;
+                    return false;
                 }
 
                 // By default it will fallback to false if firebase error happens


### PR DESCRIPTION
This pull request updates the `useTMB` hook to handle additional cases for localStorage values, ensuring more robust behavior when determining the `is_tmb_enabled` status.

Enhancements to localStorage value handling:

* [`src/hooks/useTMB.ts`](diffhunk://#diff-1693c842cbdff131e5a6d04a38e26e478527cfc01996cdc0d2ff41c37f551958L118-R128): Modified the logic to explicitly handle both `'true'` and `'false'` values from localStorage, ensuring that the `is_tmb_enabled` status is correctly set and the determination process is finalized in both cases. [[1]](diffhunk://#diff-1693c842cbdff131e5a6d04a38e26e478527cfc01996cdc0d2ff41c37f551958L118-R128) [[2]](diffhunk://#diff-1693c842cbdff131e5a6d04a38e26e478527cfc01996cdc0d2ff41c37f551958L147-R162)