### PR TITLE
fix: remove auto login to oauth page

### DIFF
--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -4,6 +4,7 @@ import Cookies from 'js-cookie';
 import { Outlet } from 'react-router-dom';
 import { api_base } from '@/external/bot-skeleton';
 import useTMB from '@/hooks/useTMB';
+import { handleOidcAuthFailure } from '@/utils/auth-utils';
 import { requestOidcAuthentication } from '@deriv-com/auth-client';
 import { useDevice } from '@deriv-com/ui';
 import { crypto_currencies_display_order, fiat_currencies_display_order } from '../shared';
@@ -149,19 +150,20 @@ const Layout = () => {
                     if (query_param_currency) {
                         sessionStorage.setItem('query_param_currency', query_param_currency);
                     }
-                    requestOidcAuthentication({
-                        redirectCallbackUri: `${window.location.origin}/callback`,
-                        ...(query_param_currency
-                            ? {
-                                  state: {
-                                      account: query_param_currency,
-                                  },
-                              }
-                            : {}),
-                    }).catch(err => {
-                        // eslint-disable-next-line no-console
-                        console.error(err);
-                    });
+                    try {
+                        await requestOidcAuthentication({
+                            redirectCallbackUri: `${window.location.origin}/callback`,
+                            ...(query_param_currency
+                                ? {
+                                      state: {
+                                          account: query_param_currency,
+                                      },
+                                  }
+                                : {}),
+                        });
+                    } catch (err) {
+                        handleOidcAuthFailure(err);
+                    }
                 }
             } catch (err) {
                 // eslint-disable-next-line no-console

--- a/src/hooks/auth/useOauth2.ts
+++ b/src/hooks/auth/useOauth2.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useEffect } from 'react';
 import Cookies from 'js-cookie';
 import RootStore from '@/stores/root-store';
+import { handleOidcAuthFailure } from '@/utils/auth-utils';
 import { Analytics } from '@deriv-com/analytics';
 import { OAuth2Logout, requestOidcAuthentication } from '@deriv-com/auth-client';
 
@@ -78,12 +79,10 @@ export const useOauth2 = ({
                 redirectCallbackUri: `${window.location.origin}/callback`,
                 postLogoutRedirectUri: window.location.origin,
             }).catch(err => {
-                // eslint-disable-next-line no-console
-                console.error('Error during OAuth2 login retrigger:', err);
+                handleOidcAuthFailure(err);
             });
         } catch (error) {
-            // eslint-disable-next-line no-console
-            console.error('Error during OAuth2 login retrigger:', error);
+            handleOidcAuthFailure(error);
         }
     };
 

--- a/src/hooks/useTMB.ts
+++ b/src/hooks/useTMB.ts
@@ -48,7 +48,7 @@ const useTMB = (): UseTMBReturn => {
         hasLoggedRef.current = true;
     }
 
-    const isEndpointPage = useMemo(() => window.location.pathname.includes('endpoint'), []);
+    // const isEndpointPage = useMemo(() => window.location.pathname.includes('endpoint'), []);
     const isCallbackPage = useMemo(() => window.location.pathname === '/callback', []);
     const domains = useMemo(
         () => ['deriv.com', 'deriv.dev', 'binary.sx', 'pages.dev', 'localhost', 'deriv.be', 'deriv.me'],
@@ -251,11 +251,11 @@ const useTMB = (): UseTMBReturn => {
             localStorage.removeItem('active_loginid');
             localStorage.removeItem('clientAccounts');
             localStorage.removeItem('accountsList');
-            // Redirect to OAuth authentication instead of just logging out
-            window.location.replace(generateOAuthURL());
+            // Go to logged out version of the app instead of redirecting to OAuth
+            window.location.reload();
         } catch (error) {
             // eslint-disable-next-line no-console
-            console.error('Failed to redirect to OAuth:', error);
+            console.error('Failed to logout:', error);
             return handleLogout();
         }
     }, []);
@@ -300,8 +300,8 @@ const useTMB = (): UseTMBReturn => {
                     activeSessionsRef.current = activeSessions;
                 }
 
-                // If no active sessions and either not on endpoint page or explicitly from login button
-                if (!activeSessions?.active && (!isEndpointPage || fromLoginButton)) {
+                // Only redirect if explicitly from login button
+                if (!activeSessions?.active && fromLoginButton) {
                     console.error('Failed to get active sessions: No data returned');
                     TMBState.checkInProgress = false;
 

--- a/src/pages/main/main.tsx
+++ b/src/pages/main/main.tsx
@@ -17,6 +17,7 @@ import { useOauth2 } from '@/hooks/auth/useOauth2';
 import { useApiBase } from '@/hooks/useApiBase';
 import { useStore } from '@/hooks/useStore';
 import useTMB from '@/hooks/useTMB';
+import { handleOidcAuthFailure } from '@/utils/auth-utils';
 import {
     LabelPairedChartLineCaptionRegularIcon,
     LabelPairedObjectsColumnCaptionRegularIcon,
@@ -242,19 +243,20 @@ const AppWrapper = observer(() => {
                 if (tmbEnabled) {
                     await onRenderTMBCheck();
                 } else {
-                    await requestOidcAuthentication({
-                        redirectCallbackUri: `${window.location.origin}/callback`,
-                        ...(query_param_currency
-                            ? {
-                                  state: {
-                                      account: query_param_currency,
-                                  },
-                              }
-                            : {}),
-                    }).catch(err => {
-                        // eslint-disable-next-line no-console
-                        console.error(err);
-                    });
+                    try {
+                        await requestOidcAuthentication({
+                            redirectCallbackUri: `${window.location.origin}/callback`,
+                            ...(query_param_currency
+                                ? {
+                                      state: {
+                                          account: query_param_currency,
+                                      },
+                                  }
+                                : {}),
+                        });
+                    } catch (err) {
+                        handleOidcAuthFailure(err);
+                    }
                 }
             } catch (error) {
                 // eslint-disable-next-line no-console

--- a/src/utils/auth-utils.ts
+++ b/src/utils/auth-utils.ts
@@ -1,6 +1,7 @@
 /**
  * Utility functions for authentication-related operations
  */
+import Cookies from 'js-cookie';
 
 /**
  * Clears authentication data from local storage and reloads the page
@@ -14,4 +15,30 @@ export const clearAuthData = (): void => {
     localStorage.removeItem('client.accounts');
     localStorage.removeItem('client.country');
     location.reload();
+};
+
+/**
+ * Handles OIDC authentication failure by clearing auth data and showing logged out view
+ * @param error - The error that occurred during OIDC authentication
+ */
+export const handleOidcAuthFailure = (error: any): void => {
+    // Log the error
+    console.error('OIDC authentication failed:', error);
+
+    // Clear auth data
+    localStorage.removeItem('authToken');
+    localStorage.removeItem('active_loginid');
+    localStorage.removeItem('clientAccounts');
+    localStorage.removeItem('accountsList');
+
+    // Set logged_state cookie to false
+    Cookies.set('logged_state', 'false', {
+        domain: window.location.hostname.split('.').slice(-2).join('.'),
+        expires: 30,
+        path: '/',
+        secure: true,
+    });
+
+    // Reload the page to show the logged out view
+    window.location.reload();
 };


### PR DESCRIPTION
This pull request introduces improvements to error handling for OIDC authentication failures, refactors login-related logic, and updates session management. It centralizes the handling of OIDC authentication errors using a new utility function, modifies how failed login attempts are processed, and adjusts session-related behaviors for better user experience.

### Error Handling Improvements:
* Added the `handleOidcAuthFailure` utility function in `src/utils/auth-utils.ts` to centralize the handling of OIDC authentication failures. This function clears authentication data, sets a `logged_state` cookie to `false`, and reloads the page to show the logged-out view.

### Refactoring Login Logic:
* Replaced `.catch` blocks with `try...catch` for OIDC authentication in multiple components (`src/components/layout/header/header.tsx`, `src/components/layout/index.tsx`, `src/pages/main/main.tsx`) to use the new `handleOidcAuthFailure` function for error handling. [[1]](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3L154-R160) [[2]](diffhunk://#diff-297411bbdb20a2ca96207a6e5284cd0598f90d22b776fa55232a04fae431835aL161-R166) [[3]](diffhunk://#diff-e315c9587afa8674eab883837b77bd5ad552be5a25c2b29ea062b071ba4aff36L254-R259)
* Updated the OIDC authentication process to redirect users to the OAuth URL upon failure in `src/components/layout/header/header.tsx`.

### Session Management Updates:
* Modified `useTMB` hook in `src/hooks/useTMB.ts` to reload the app instead of redirecting to the OAuth URL when logging out, and adjusted logic to only redirect if explicitly triggered by the login button. [[1]](diffhunk://#diff-1693c842cbdff131e5a6d04a38e26e478527cfc01996cdc0d2ff41c37f551958L254-R258) [[2]](diffhunk://#diff-1693c842cbdff131e5a6d04a38e26e478527cfc01996cdc0d2ff41c37f551958L303-R304)

### Codebase Cleanup:
* Removed unused `isEndpointPage` variable from `useTMB` in `src/hooks/useTMB.ts`.

### Dependency Updates:
* Imported `handleOidcAuthFailure` in files where OIDC authentication is handled (`src/components/layout/index.tsx`, `src/hooks/auth/useOauth2.ts`, `src/pages/main/main.tsx`). [[1]](diffhunk://#diff-297411bbdb20a2ca96207a6e5284cd0598f90d22b776fa55232a04fae431835aR7) [[2]](diffhunk://#diff-7ed7d4a03c35423f9e58a16d28f0b5af98eee2e3f4e729a311f562cd8b5d268bR5) [[3]](diffhunk://#diff-e315c9587afa8674eab883837b77bd5ad552be5a25c2b29ea062b071ba4aff36R20)