### PR TITLE
fix: tmb loading issue

### DIFF
--- a/src/components/auth-loading-wrapper/index.tsx
+++ b/src/components/auth-loading-wrapper/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useOauth2 } from '@/hooks/auth/useOauth2';
+import useTMB from '@/hooks/useTMB';
 import { Loader } from '@deriv-com/ui';
 
 type AuthLoadingWrapperProps = {
@@ -8,8 +9,11 @@ type AuthLoadingWrapperProps = {
 
 const AuthLoadingWrapper = ({ children }: AuthLoadingWrapperProps) => {
     const { isSingleLoggingIn } = useOauth2();
+    const { isTmbEnabled } = useTMB();
 
-    if (isSingleLoggingIn) {
+    const is_tmb_enabled = isTmbEnabled() || window.is_tmb_enabled === true;
+
+    if (isSingleLoggingIn && !is_tmb_enabled) {
         return <Loader isFullScreen />;
     }
 

--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -42,7 +42,7 @@ const AppHeader = observer(() => {
     const is_tmb_enabled = isTmbEnabled() || window.is_tmb_enabled === true;
 
     const renderAccountSection = useCallback(() => {
-        if (isAuthorizing || isSingleLoggingIn) {
+        if (isAuthorizing || (isSingleLoggingIn && !is_tmb_enabled)) {
             return <AccountsInfoLoader isLoggedIn isMobile={!isDesktop} speed={3} />;
         } else if (activeLoginid) {
             return (


### PR DESCRIPTION
This pull request introduces changes to integrate the `isTmbEnabled` functionality into the authentication and loading flow, ensuring that certain components behave differently based on whether TMB (presumably a feature flag or system) is enabled. The most important changes include modifications to the `AuthLoadingWrapper` and `AppHeader` components to account for the new `isTmbEnabled` logic.

### Integration of `isTmbEnabled` functionality:

* [`src/components/auth-loading-wrapper/index.tsx`](diffhunk://#diff-5d6072c21e9c90b4d9ce49189fcd39000a8ecb55de7658bd5facd3aad8c5b4d2R3): Added the `useTMB` hook and updated the loading logic in `AuthLoadingWrapper` to check if TMB is enabled (`is_tmb_enabled`). If `isSingleLoggingIn` is true and TMB is not enabled, the full-screen loader is displayed. [[1]](diffhunk://#diff-5d6072c21e9c90b4d9ce49189fcd39000a8ecb55de7658bd5facd3aad8c5b4d2R3) [[2]](diffhunk://#diff-5d6072c21e9c90b4d9ce49189fcd39000a8ecb55de7658bd5facd3aad8c5b4d2R12-R16)

* [`src/components/layout/header/header.tsx`](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3L45-R45): Updated the `AppHeader` component to incorporate the `is_tmb_enabled` check in the `renderAccountSection` logic. This ensures that the account section loader is displayed only when `isAuthorizing` or `isSingleLoggingIn` and TMB is not enabled.