### PR TITLE
fix: auth loader issue

### DIFF
--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -23,7 +23,11 @@ import MobileMenu from './mobile-menu';
 import PlatformSwitcher from './platform-switcher';
 import './header.scss';
 
-const AppHeader = observer(() => {
+type TAppHeaderProps = {
+    isAuthenticating?: boolean;
+};
+
+const AppHeader = observer(({ isAuthenticating }: TAppHeaderProps) => {
     const { isDesktop } = useDevice();
     const { isAuthorizing, activeLoginid } = useApiBase();
     const { client } = useStore() ?? {};
@@ -40,9 +44,11 @@ const AppHeader = observer(() => {
     const { hubEnabledCountryList } = useFirebaseCountriesConfig();
     const { onRenderTMBCheck, isTmbEnabled } = useTMB();
     const is_tmb_enabled = isTmbEnabled() || window.is_tmb_enabled === true;
+    // No need for additional state management here since we're handling it in the layout component
 
     const renderAccountSection = useCallback(() => {
-        if (isAuthorizing || (isSingleLoggingIn && !is_tmb_enabled)) {
+        // Show loader during authentication processes
+        if (isAuthenticating || isAuthorizing || (isSingleLoggingIn && !is_tmb_enabled)) {
             return <AccountsInfoLoader isLoggedIn isMobile={!isDesktop} speed={3} />;
         } else if (activeLoginid) {
             return (
@@ -177,6 +183,7 @@ const AppHeader = observer(() => {
             );
         }
     }, [
+        isAuthenticating,
         isAuthorizing,
         isSingleLoggingIn,
         isDesktop,


### PR DESCRIPTION
This pull request introduces enhancements to authentication state management and improves the user experience during authentication processes. Key changes include adding an `isAuthenticating` state to track authentication progress, updating components to use this state, and modifying hooks to handle authentication state transitions.

### Authentication State Management Enhancements:

* **`src/components/layout/index.tsx`:** Introduced `isAuthenticating` state in the `Layout` component to track authentication progress and prevent UI flashing. Added `isInitialAuthCheckComplete` state to ensure smooth transitions after authentication checks. Updated the `AppHeader` component to receive `isAuthenticating` as a prop. [[1]](diffhunk://#diff-297411bbdb20a2ca96207a6e5284cd0598f90d22b776fa55232a04fae431835aR38) [[2]](diffhunk://#diff-297411bbdb20a2ca96207a6e5284cd0598f90d22b776fa55232a04fae431835aR128) [[3]](diffhunk://#diff-297411bbdb20a2ca96207a6e5284cd0598f90d22b776fa55232a04fae431835aR167-R176) [[4]](diffhunk://#diff-297411bbdb20a2ca96207a6e5284cd0598f90d22b776fa55232a04fae431835aR191-R208)

* **`src/components/layout/header/header.tsx`:** Updated the `AppHeader` component to accept `isAuthenticating` as a prop and display a loader during authentication processes. Adjusted the `renderAccountSection` logic to incorporate the new state. [[1]](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3L26-R30) [[2]](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3R47-R51) [[3]](diffhunk://#diff-369c35ed105770696d1e076b245f598bf8b44660ac3fefe85ee26b5f31e5b7c3R186)

### Hook Modifications for Authentication Handling:

* **`src/hooks/useTMB.ts`:** Updated the `onRenderTMBCheck` function to accept an optional `setIsAuthenticating` callback for managing authentication state. Added logic to set `isAuthenticating` to `false` after authentication checks or failures. [[1]](diffhunk://#diff-1693c842cbdff131e5a6d04a38e26e478527cfc01996cdc0d2ff41c37f551958L21-R21) [[2]](diffhunk://#diff-1693c842cbdff131e5a6d04a38e26e478527cfc01996cdc0d2ff41c37f551958L288-R288) [[3]](diffhunk://#diff-1693c842cbdff131e5a6d04a38e26e478527cfc01996cdc0d2ff41c37f551958L307-R316) [[4]](diffhunk://#diff-1693c842cbdff131e5a6d04a38e26e478527cfc01996cdc0d2ff41c37f551958R370-R372)