### PR TITLE
fix: session active call

### DIFF
--- a/src/hooks/useTMB.ts
+++ b/src/hooks/useTMB.ts
@@ -194,7 +194,7 @@ const useTMB = (): UseTMBReturn => {
         const initializeHook = async () => {
             try {
                 // Pre-fetch active sessions if needed
-                if (!isCallbackPage) {
+                if (!isCallbackPage && window.is_tmb_enabled) {
                     try {
                         // This is a critical step - we need to await this
                         const activeSessions = await getActiveSessions();
@@ -295,7 +295,7 @@ const useTMB = (): UseTMBReturn => {
                 // Use pre-fetched active sessions if available, otherwise fetch them
                 let activeSessions = activeSessionsRef.current;
 
-                if (!activeSessions) {
+                if (!activeSessions && window.is_tmb_enabled) {
                     activeSessions = await getActiveSessions();
                     activeSessionsRef.current = activeSessions;
                 }


### PR DESCRIPTION
This pull request updates the `useTMB` hook in `src/hooks/useTMB.ts` to include additional checks for `window.is_tmb_enabled` before performing certain operations. These changes ensure that functionality dependent on TMB is only executed when TMB is enabled.

Key changes to conditional logic in `useTMB`:

* Updated the `initializeHook` function to check `window.is_tmb_enabled` before pre-fetching active sessions. This prevents unnecessary operations when TMB is disabled.
* Modified the logic for fetching active sessions to include a check for `window.is_tmb_enabled`. This ensures active sessions are only fetched when TMB is enabled.