### PR TITLE
fix: tmb check for the demo account

### DIFF
--- a/src/hooks/useTMB.ts
+++ b/src/hooks/useTMB.ts
@@ -328,11 +328,20 @@ const useTMB = (): UseTMBReturn => {
 
                         let selectedToken = activeSessions.tokens[0];
                         if (accountParam) {
-                            const matchingToken = activeSessions.tokens.find(
-                                (token: TokenItem) => token.cur === accountParam
-                            );
-                            if (matchingToken) {
-                                selectedToken = matchingToken;
+                            if (accountParam === 'demo') {
+                                const demoToken = activeSessions.tokens.find(
+                                    (token: TokenItem) => token.loginid && token.loginid.includes('VR')
+                                );
+                                if (demoToken) {
+                                    selectedToken = demoToken;
+                                }
+                            } else {
+                                const matchingToken = activeSessions.tokens.find(
+                                    (token: TokenItem) => token.cur === accountParam
+                                );
+                                if (matchingToken) {
+                                    selectedToken = matchingToken;
+                                }
                             }
                         }
 


### PR DESCRIPTION
This pull request introduces a small but important enhancement to the `useTMB` hook. It adds support for handling a special `accountParam` value of `'demo'` by selecting a token with a login ID containing `'VR'`.

### Key Change:
* **Enhanced token selection logic in `useTMB`**: Added a condition to check if `accountParam` is `'demo'`. If true, the hook now selects a token with a login ID containing `'VR'` from the `activeSessions.tokens` array. This improves flexibility in handling demo accounts. (`[src/hooks/useTMB.tsR331-R346](diffhunk://#diff-1693c842cbdff131e5a6d04a38e26e478527cfc01996cdc0d2ff41c37f551958R331-R346)`)