### PR TITLE
Rupato/fix: codeQL workflows

### DIFF
--- a/.github/workflows/build-and-deploy-production.yml
+++ b/.github/workflows/build-and-deploy-production.yml
@@ -14,6 +14,8 @@ jobs:
         timeout-minutes: 30
         runs-on: ubuntu-latest
         environment: production
+        permissions:
+            contents: read
         steps:
             - name: Checkout to main branch
               uses: actions/checkout@v4

--- a/.github/workflows/build-and-deploy-staging.yml
+++ b/.github/workflows/build-and-deploy-staging.yml
@@ -14,6 +14,8 @@ jobs:
         timeout-minutes: 30
         runs-on: ubuntu-latest
         environment: staging
+        permissions:
+            contents: read
         steps:
             - name: Checkout to main branch
               uses: actions/checkout@v4

--- a/.github/workflows/sync-translations.yml
+++ b/.github/workflows/sync-translations.yml
@@ -12,6 +12,8 @@ jobs:
   sync_translations:
     runs-on: ubuntu-latest
     environment: staging
+    permissions:
+      contents: read
     steps:
       - name: Sync Bots translations
         uses: deriv-com/translations/.github/actions/extract_and_sync_translations@master
@@ -28,6 +30,8 @@ jobs:
   sync_translations_production:
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: read
     steps:
       - name: Sync Bots translations
         uses: deriv-com/translations/.github/actions/extract_and_sync_translations@master


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to explicitly set `permissions` for the `contents` scope to `read`. This change enhances security by adhering to the principle of least privilege, ensuring that workflows only have the permissions they need.

### Workflow updates:

* [`.github/workflows/build-and-deploy-production.yml`](diffhunk://#diff-d8dfcbc7adf0e8cc7010e2eb020a5be671e7fed87aa32446ae7ef0e66fc1bfcaR17-R18): Added `permissions: contents: read` to the `jobs` section for the production deployment workflow.
* [`.github/workflows/build-and-deploy-staging.yml`](diffhunk://#diff-b709f2739a5258d6c2c45e190ddc8e9329c2492822f44b593a8de5145e930b42R17-R18): Added `permissions: contents: read` to the `jobs` section for the staging deployment workflow.
* [`.github/workflows/sync-translations.yml`](diffhunk://#diff-5568dd87e11a1bad51729c7af7c4289b67036708d15be275d05e0ffe4a416758R15-R16): Added `permissions: contents: read` to both the `sync_translations` and `sync_translations_production` jobs to restrict access to repository contents. [[1]](diffhunk://#diff-5568dd87e11a1bad51729c7af7c4289b67036708d15be275d05e0ffe4a416758R15-R16) [[2]](diffhunk://#diff-5568dd87e11a1bad51729c7af7c4289b67036708d15be275d05e0ffe4a416758R33-R34)