### PR TITLE
fix: domain cookie domain name

### DIFF
--- a/src/app/CoreStoreProvider.tsx
+++ b/src/app/CoreStoreProvider.tsx
@@ -24,6 +24,7 @@ type TClientInformation = {
     landing_company_shortcode?: string;
 };
 const CoreStoreProvider: React.FC<{ children: React.ReactNode }> = observer(({ children }) => {
+    const currentDomain = useMemo(() => '.' + window.location.hostname.split('.').slice(-2).join('.'), []);
     const { isAuthorizing, isAuthorized, connectionStatus, accountList, activeLoginid } = useApiBase();
 
     const appInitialization = useRef(false);
@@ -181,7 +182,9 @@ const CoreStoreProvider: React.FC<{ children: React.ReactNode }> = observer(({ c
                     landing_company_shortcode: activeAccount?.landing_company_name,
                 };
 
-                Cookies.set('client_information', JSON.stringify(client_information));
+                Cookies.set('client_information', JSON.stringify(client_information), {
+                    domain: currentDomain,
+                });
 
                 api_base.api
                     .landingCompany({


### PR DESCRIPTION
This pull request introduces a change to the `CoreStoreProvider` component in `src/app/CoreStoreProvider.tsx` to ensure cookies are set with the appropriate domain. The key updates involve calculating the current domain dynamically and using it when setting cookies.

### Key Changes:

**Enhancements to Cookie Management:**
* Added a `currentDomain` variable using `useMemo` to dynamically calculate the domain based on the current hostname (`src/app/CoreStoreProvider.tsx`, [src/app/CoreStoreProvider.tsxR27](diffhunk://#diff-5ec7969cf78888b570b3224805b4252b136ff69101053e09e361de4be5cdded8R27)).
* Updated the `Cookies.set` function to include the `domain` option, ensuring cookies are scoped to the calculated domain (`src/app/CoreStoreProvider.tsx`, [src/app/CoreStoreProvider.tsxL184-R187](diffhunk://#diff-5ec7969cf78888b570b3224805b4252b136ff69101053e09e361de4be5cdded8L184-R187)).