### PR TITLE
Prince/fix boom 600 & 900 market icon

### DIFF
--- a/src/components/market/market-icon.tsx
+++ b/src/components/market/market-icon.tsx
@@ -167,6 +167,9 @@ const MARKET_ICONS = {
     BOOM600: lazy(() =>
         import('@deriv/quill-icons/Markets').then(module => ({ default: module.MarketDerivedBoom600Icon }))
     ),
+    BOOM900: lazy(() =>
+        import('@deriv/quill-icons/Markets').then(module => ({ default: module.MarketDerivedBoom900Icon }))
+    ),
     BOOM1000: lazy(() =>
         import('@deriv/quill-icons/Markets').then(module => ({ default: module.MarketDerivedBoom1000Icon }))
     ),


### PR DESCRIPTION
- Added missing icon for boom600 instrument. 
- Added missing icon for boom900 instrument. 