### PR TITLE
fix: for self exclusion trackjsissue

### DIFF
--- a/src/components/trade-animation/trade-animation.tsx
+++ b/src/components/trade-animation/trade-animation.tsx
@@ -43,7 +43,7 @@ const TradeAnimation = observer(({ className, should_show_overlay }: TTradeAnima
 
     // perform self-exclusion checks which will be stored under the self-exclusion-store
     React.useEffect(() => {
-        if (!client.loginid && !client.is_logged_in) return;
+        if (!client.loginid || !client.is_logged_in) return;
         performSelfExclusionCheck();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);


### PR DESCRIPTION
This pull request includes a minor but important fix to the `TradeAnimation` component in `trade-animation.tsx`. The change ensures that the self-exclusion check is performed correctly by updating the condition to use a logical OR operator instead of an AND operator.

* [`src/components/trade-animation/trade-animation.tsx`](diffhunk://#diff-c2fdd1b296d39bf2cc95d7924d9498678ae883af38b66bdc7ac0207abe30c085L46-R46): Updated the `React.useEffect` dependency condition to check if either `client.loginid` is missing or `client.is_logged_in` is false, ensuring the self-exclusion check is triggered appropriately.