### PR TITLE
fix: authorization error on self exclusion

### DIFF
--- a/src/stores/self-exclusion-store.ts
+++ b/src/stores/self-exclusion-store.ts
@@ -67,13 +67,17 @@ export default class SelfExclusionStore {
         if (api_base.api && api_base.is_authorized && V2GetActiveClientId()) {
             api_base.api
                 .getSelfExclusion()
-                .then(({ get_self_exclusion }) => {
+                .then(({ get_self_exclusion }: { get_self_exclusion: { max_losses?: number } }) => {
                     const { max_losses: maxLosses } = get_self_exclusion;
                     if (maxLosses) {
                         this.setApiMaxLosses(maxLosses);
                     }
                 })
-                .catch(error => {
+                .catch((error: { code?: string; message?: string }) => {
+                    if (error?.code === 'AuthorizationRequired') {
+                        this.core.client.logout();
+                        return;
+                    }
                     console.error('Error fetching self-exclusion data:', error);
                 });
         }


### PR DESCRIPTION
This pull request updates the error handling and type definitions in the `SelfExclusionStore` class to improve type safety and handle specific authorization errors gracefully.

### Type safety improvements:
* Updated the `getSelfExclusion` response to include a type definition for `get_self_exclusion` with an optional `max_losses` property. (`[src/stores/self-exclusion-store.tsL70-R80](diffhunk://#diff-172218cfc4b84f2c01b16f2169441e3b8273810e60eec63bf7e4e76387dbd1cfL70-R80)`)

### Error handling enhancements:
* Enhanced the `.catch` block to handle errors with a specific structure, checking for an `AuthorizationRequired` error code. If encountered, the client is logged out before logging the error. (`[src/stores/self-exclusion-store.tsL70-R80](diffhunk://#diff-172218cfc4b84f2c01b16f2169441e3b8273810e60eec63bf7e4e76387dbd1cfL70-R80)`)