### PR TITLE
Rupato/BOT-2932/remove the logout button from dbot

### DIFF
--- a/src/components/layout/header/common/account-swticher-footer.tsx
+++ b/src/components/layout/header/common/account-swticher-footer.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import classNames from 'classnames';
-import RectangleSkeleton from '@/components/loader/rectangle-skeleton';
 import { standalone_routes } from '@/components/shared';
 import Button from '@/components/shared_ui/button';
-import Text from '@/components/shared_ui/text';
 import { useFirebaseCountriesConfig } from '@/hooks/firebase/useFirebaseCountriesConfig';
 import useStoreWalletAccountsList from '@/hooks/useStoreWalletAccountsList';
 import { getWalletUrl, handleTraderHubRedirect } from '@/utils/traders-hub-redirect';
-import { LegacyLogout1pxIcon } from '@deriv/quill-icons';
 import { Localize, localize } from '@deriv-com/translations';
 import { AccountSwitcher as UIAccountSwitcher } from '@deriv-com/ui';
 
@@ -19,7 +16,7 @@ type TAccountSwitcherFooter = {
 };
 import { AccountSwitcherDivider } from './utils';
 
-const AccountSwitcherFooter = ({ oAuthLogout, loginid, is_logging_out, residence }: TAccountSwitcherFooter) => {
+const AccountSwitcherFooter = ({ loginid, residence }: TAccountSwitcherFooter) => {
     const accountList = JSON.parse(localStorage.getItem('clientAccounts') || '{}');
     const account_currency = loginid ? accountList[loginid]?.currency : '';
     const show_manage_button = loginid?.includes('CR') || loginid?.includes('MF');
@@ -84,29 +81,7 @@ const AccountSwitcherFooter = ({ oAuthLogout, loginid, is_logging_out, residence
                         <Localize i18n_default_text='Manage accounts' />
                     </Button>
                 )}
-                <UIAccountSwitcher.Footer>
-                    {is_logging_out ? (
-                        <div className='deriv-account-switcher__logout--loader'>
-                            <RectangleSkeleton width='120px' height='12px' />
-                        </div>
-                    ) : (
-                        <div id='dt_logout_button' className='deriv-account-switcher__logout' onClick={oAuthLogout}>
-                            <Text
-                                color='prominent'
-                                size='xs'
-                                align='left'
-                                className='deriv-account-switcher__logout-text'
-                            >
-                                {localize('Logout')}
-                            </Text>
-                            <LegacyLogout1pxIcon
-                                iconSize='xs'
-                                fill='var(--text-general)'
-                                className='icon-general-fill-path'
-                            />
-                        </div>
-                    )}
-                </UIAccountSwitcher.Footer>
+                {/* Logout button removed from Desktop interface as per acceptance criteria */}
             </div>
         </div>
     );

--- a/src/components/layout/header/mobile-menu/use-mobile-menu-config.tsx
+++ b/src/components/layout/header/mobile-menu/use-mobile-menu-config.tsx
@@ -2,7 +2,6 @@ import { ComponentProps, ReactNode, useMemo } from 'react';
 import Livechat from '@/components/chat/Livechat';
 import useIsLiveChatWidgetAvailable from '@/components/chat/useIsLiveChatWidgetAvailable';
 import { standalone_routes } from '@/components/shared';
-import { useOauth2 } from '@/hooks/auth/useOauth2';
 import { useFirebaseCountriesConfig } from '@/hooks/firebase/useFirebaseCountriesConfig';
 import useRemoteConfig from '@/hooks/growthbook/useRemoteConfig';
 import { useIsIntercomAvailable } from '@/hooks/useIntercom';
@@ -15,7 +14,6 @@ import {
     LegacyChartsIcon,
     LegacyHelpCentreIcon,
     LegacyHomeOldIcon,
-    LegacyLogout1pxIcon,
     LegacyProfileSmIcon,
     LegacyReportsIcon,
     LegacyResponsibleTradingIcon,
@@ -46,8 +44,6 @@ type TMenuConfig = {
 const useMobileMenuConfig = (client?: RootStore['client']) => {
     const { localize } = useTranslations();
     const { is_dark_mode_on, toggleTheme } = useThemeSwitcher();
-
-    const { oAuthLogout } = useOauth2({ handleLogout: async () => client?.logout(), client });
 
     const { data } = useRemoteConfig(true);
     const { cs_chat_whatsapp } = data;
@@ -190,17 +186,8 @@ const useMobileMenuConfig = (client?: RootStore['client']) => {
                       }
                     : null,
             ].filter(Boolean) as TMenuConfig,
-            client?.is_logged_in
-                ? [
-                      {
-                          as: 'button',
-                          label: localize('Log out'),
-                          LeftComponent: LegacyLogout1pxIcon,
-                          onClick: oAuthLogout,
-                          removeBorderBottom: true,
-                      },
-                  ]
-                : [],
+            // Logout button removed from mobile interface as per acceptance criteria
+            [],
         ],
         [is_virtual, currency, is_logged_in, client_residence, is_tmb_enabled]
     );


### PR DESCRIPTION
This pull request removes the logout functionality from both desktop and mobile interfaces as part of the acceptance criteria. It also simplifies the code by removing unused imports and dependencies related to logout functionality.

### Removal of Logout Functionality:

* [`src/components/layout/header/common/account-swticher-footer.tsx`](diffhunk://#diff-7431f2f873b7b5cbcd9127a9c3985b9f7f8fa732f8fc2cc0c136d8f7c878fa8cL22-R19): Removed the logout button from the desktop account switcher footer and updated the `AccountSwitcherFooter` component to exclude `oAuthLogout` and `is_logging_out` props. [[1]](diffhunk://#diff-7431f2f873b7b5cbcd9127a9c3985b9f7f8fa732f8fc2cc0c136d8f7c878fa8cL22-R19) [[2]](diffhunk://#diff-7431f2f873b7b5cbcd9127a9c3985b9f7f8fa732f8fc2cc0c136d8f7c878fa8cL87-R84)
* [`src/components/layout/header/mobile-menu/use-mobile-menu-config.tsx`](diffhunk://#diff-d1dbf017cbc6be00aadfd73ef141a2bfdf9f90b8464e96f24ae4f7870bdf6477L50-L51): Removed the logout button from the mobile menu configuration and eliminated the `oAuthLogout` dependency and related code. [[1]](diffhunk://#diff-d1dbf017cbc6be00aadfd73ef141a2bfdf9f90b8464e96f24ae4f7870bdf6477L50-L51) [[2]](diffhunk://#diff-d1dbf017cbc6be00aadfd73ef141a2bfdf9f90b8464e96f24ae4f7870bdf6477L193-R190)

### Code Simplification:

* [`src/components/layout/header/common/account-swticher-footer.tsx`](diffhunk://#diff-7431f2f873b7b5cbcd9127a9c3985b9f7f8fa732f8fc2cc0c136d8f7c878fa8cL3-L10): Removed unused imports such as `RectangleSkeleton`, `Text`, and `LegacyLogout1pxIcon`.
* [`src/components/layout/header/mobile-menu/use-mobile-menu-config.tsx`](diffhunk://#diff-d1dbf017cbc6be00aadfd73ef141a2bfdf9f90b8464e96f24ae4f7870bdf6477L5): Removed unused imports, including `useOauth2` and `LegacyLogout1pxIcon`. [[1]](diffhunk://#diff-d1dbf017cbc6be00aadfd73ef141a2bfdf9f90b8464e96f24ae4f7870bdf6477L5) [[2]](diffhunk://#diff-d1dbf017cbc6be00aadfd73ef141a2bfdf9f90b8464e96f24ae4f7870bdf6477L18)