### PR TITLE
fix: account switcher bugs

### DIFF
--- a/src/components/layout/header/common/account-swticher-footer.tsx
+++ b/src/components/layout/header/common/account-swticher-footer.tsx
@@ -13,12 +13,14 @@ type TAccountSwitcherFooter = {
     loginid?: string;
     is_logging_out?: boolean;
     residence?: string;
+    type?: 'demo' | 'real';
 };
 import { AccountSwitcherDivider } from './utils';
 
-const AccountSwitcherFooter = ({ loginid, residence }: TAccountSwitcherFooter) => {
+const AccountSwitcherFooter = ({ loginid, residence, type }: TAccountSwitcherFooter) => {
     const accountList = JSON.parse(localStorage.getItem('clientAccounts') || '{}');
     const account_currency = loginid ? accountList[loginid]?.currency : '';
+    // Hide manage button for demo accounts (virtual accounts)
     const show_manage_button = loginid?.includes('CR') || loginid?.includes('MF');
     const { has_wallet = false } = useStoreWalletAccountsList() || {};
     const { hubEnabledCountryList } = useFirebaseCountriesConfig();
@@ -54,18 +56,20 @@ const AccountSwitcherFooter = ({ loginid, residence }: TAccountSwitcherFooter) =
         console.error('Error parsing redirect URL:', error);
     }
 
+    const is_virtual_tab = type === 'demo';
+
     return (
         <div className=''>
             <UIAccountSwitcher.TradersHubLink href={final_url_str}>
                 {localize(`Looking for CFD accounts? Go to Trader's Hub`)}
             </UIAccountSwitcher.TradersHubLink>
             <AccountSwitcherDivider />
-            <div
-                className={classNames('account-switcher-footer__actions', {
-                    'account-switcher-footer__actions--hide-manage-button': !show_manage_button,
-                })}
-            >
-                {show_manage_button && (
+            {!is_virtual_tab && (
+                <div
+                    className={classNames('account-switcher-footer__actions', {
+                        'account-switcher-footer__actions--hide-manage-button': !show_manage_button,
+                    })}
+                >
                     <Button
                         id='manage-button'
                         className='manage-button'
@@ -80,9 +84,9 @@ const AccountSwitcherFooter = ({ loginid, residence }: TAccountSwitcherFooter) =
                     >
                         <Localize i18n_default_text='Manage accounts' />
                     </Button>
-                )}
-                {/* Logout button removed from Desktop interface as per acceptance criteria */}
-            </div>
+                    {/* Logout button removed from Desktop interface as per acceptance criteria */}
+                </div>
+            )}
         </div>
     );
 };

--- a/src/components/layout/header/common/demo-accounts.tsx
+++ b/src/components/layout/header/common/demo-accounts.tsx
@@ -52,7 +52,12 @@ const DemoAccounts = ({
                     ))}
             </UIAccountSwitcher.AccountsPanel>
             <AccountSwitcherDivider />
-            <AccountSwitcherFooter loginid={activeLoginId} oAuthLogout={oAuthLogout} is_logging_out={is_logging_out} />
+            <AccountSwitcherFooter
+                loginid={activeLoginId}
+                oAuthLogout={oAuthLogout}
+                is_logging_out={is_logging_out}
+                type='demo'
+            />
         </>
     );
 };

--- a/src/components/layout/header/common/real-accounts.tsx
+++ b/src/components/layout/header/common/real-accounts.tsx
@@ -100,6 +100,7 @@ const RealAccounts = ({
                 loginid={loginid}
                 is_logging_out={is_logging_out}
                 residence={residence}
+                type='real'
             />
         </>
     );

--- a/src/components/layout/header/common/utils.tsx
+++ b/src/components/layout/header/common/utils.tsx
@@ -17,4 +17,4 @@ export const convertCommaValue = (str: string) => {
     return Number(str.replace(/,/g, ''));
 };
 
-export const AccountSwitcherDivider = () => <Divider color='var(--general-section-2)' height='4px' />;
+export const AccountSwitcherDivider = () => <Divider color='var(--general-section-2)' height='2px' />;

--- a/src/components/layout/header/header.scss
+++ b/src/components/layout/header/header.scss
@@ -54,10 +54,10 @@
 
         &__actions {
             display: flex;
-            justify-content: space-between;
+            justify-content: right;
             align-items: center;
-            padding: 0 1rem;
             background-color: var(--du-general-main-2);
+            padding: 1.6rem 0.8rem;
 
             &--hide-manage-button {
                 justify-content: flex-end;
@@ -196,7 +196,7 @@
     &__title {
         height: 4rem;
         margin: 0 auto;
-        padding: 1.2rem 1.6rem;
+        padding: 1.2rem 0.6rem;
     }
 
     &__container--mobile {


### PR DESCRIPTION
This pull request introduces enhancements to the `AccountSwitcherFooter` component, updates styling in the header, and modifies utility functions. The main focus is on differentiating between demo and real accounts in the footer logic and improving the visual layout. Below is a summary of the most important changes grouped by theme.

### Functional Updates:

* Added a `type` property (`'demo' | 'real'`) to the `TAccountSwitcherFooter` type to distinguish between demo and real accounts. Updated the logic in `AccountSwitcherFooter` to hide the "Manage accounts" button for demo accounts. (`src/components/layout/header/common/account-swticher-footer.tsx`) [[1]](diffhunk://#diff-7431f2f873b7b5cbcd9127a9c3985b9f7f8fa732f8fc2cc0c136d8f7c878fa8cR16-R23) [[2]](diffhunk://#diff-7431f2f873b7b5cbcd9127a9c3985b9f7f8fa732f8fc2cc0c136d8f7c878fa8cR59-L68) [[3]](diffhunk://#diff-7431f2f873b7b5cbcd9127a9c3985b9f7f8fa732f8fc2cc0c136d8f7c878fa8cL83-R89)
* Passed the `type` property as `'demo'` in `DemoAccounts` and `'real'` in `RealAccounts` to ensure proper behavior in the footer. (`src/components/layout/header/common/demo-accounts.tsx`, `src/components/layout/header/common/real-accounts.tsx`) [[1]](diffhunk://#diff-797a9ee32adf3640f1ce743e02e982ab4ca7c459503c3e02d55efb653cd01e35L55-R60) [[2]](diffhunk://#diff-4de4e43d901612b973866c07cad955bf91f25d95a235e111d1dcd15b39edcbeeR103)

### Styling Updates:

* Adjusted padding and alignment in the `header.scss` file for better layout consistency:
  - Changed `justify-content` in `account-switcher-footer__actions` from `space-between` to `right` and updated padding values.
  - Reduced padding in the `header__title` element for a more compact design.

### Utility Updates:

* Reduced the height of the `AccountSwitcherDivider` component from `4px` to `2px` for a sleeker appearance. (`src/components/layout/header/common/utils.tsx`)