### PR TITLE
fix: domain generation for oauth

### DIFF
--- a/src/components/shared/utils/config/config.ts
+++ b/src/components/shared/utils/config/config.ts
@@ -150,6 +150,15 @@ export const generateOAuthURL = () => {
         localStorage.getItem('config.server_url') ||
         original_url.hostname) as string;
 
+    const current_domain = getCurrentProductionDomain();
+
+    if (original_url.hostname.includes('oauth.deriv.')) {
+        if (current_domain) {
+            const domain_suffix = current_domain.replace(/^[^.]+\./, '');
+            original_url.hostname = `oauth.${domain_suffix}`;
+        }
+    }
+
     const valid_server_urls = ['green.derivws.com', 'red.derivws.com', 'blue.derivws.com'];
     if (
         typeof configured_server_url === 'string'

--- a/src/components/shared/utils/login/login.ts
+++ b/src/components/shared/utils/login/login.ts
@@ -1,5 +1,5 @@
 import { website_name } from '@/utils/site-config';
-import { domain_app_ids, getAppId } from '../config/config';
+import { domain_app_ids, getAppId, getCurrentProductionDomain } from '../config/config';
 import { CookieStorage, isStorageSupported, LocalStore } from '../storage/storage';
 import { getStaticUrl, urlForCurrentDomain } from '../url';
 import { deriv_urls } from '../url/constants';
@@ -34,9 +34,9 @@ export const loginUrl = ({ language }: TLoginUrl) => {
         date_first_contact ? `&date_first_contact=${date_first_contact}` : ''
     }`;
     const getOAuthUrl = () => {
-        return `https://oauth.${
-            deriv_urls.DERIV_HOST_NAME
-        }/oauth2/authorize?app_id=${getAppId()}&l=${language}${marketing_queries}&brand=${website_name.toLowerCase()}`;
+        const current_domain = getCurrentProductionDomain();
+        const oauth_domain = current_domain || deriv_urls.DERIV_HOST_NAME;
+        return `https://oauth.${oauth_domain}/oauth2/authorize?app_id=${getAppId()}&l=${language}${marketing_queries}&brand=${website_name.toLowerCase()}`;
     };
 
     if (server_url && /qa/.test(server_url)) {


### PR DESCRIPTION
This pull request introduces changes to improve the handling of OAuth URLs by dynamically determining the appropriate domain based on the current production environment. The updates ensure better compatibility with different environments and enhance the flexibility of the OAuth URL generation.

### OAuth URL Improvements:

* **Dynamic domain handling in `generateOAuthURL`:** Added logic to replace the hostname with a dynamically determined OAuth domain suffix if the original hostname includes `oauth.deriv.`. This ensures the OAuth URL aligns with the current production domain. (`src/components/shared/utils/config/config.ts`)

* **Refactor in `loginUrl` function:** Updated the OAuth URL generation to use a dynamic domain (`getCurrentProductionDomain`) as a fallback to the default hostname, improving adaptability across environments. (`src/components/shared/utils/login/login.ts`)

### Codebase Maintenance:

* **Import updates in `login.ts`:** Added the `getCurrentProductionDomain` import to support the new dynamic domain logic. (`src/components/shared/utils/login/login.ts`)