### PR TITLE
Rupato/fix  dot me be

### DIFF
--- a/src/components/shared/utils/login/login.ts
+++ b/src/components/shared/utils/login/login.ts
@@ -52,12 +52,15 @@ export const loginUrl = ({ language }: TLoginUrl) => {
         return url;
     };
 
+    console.log('test getAppId', server_url);
     if (server_url && /qa/.test(server_url)) {
         return `https://${server_url}/oauth2/authorize?app_id=${getAppId()}&l=${language}${marketing_queries}&brand=${website_name.toLowerCase()}`;
     }
 
+    console.log('test getAppId', getAppId());
     if (getAppId() === domain_app_ids[window.location.hostname as keyof typeof domain_app_ids]) {
         return getOAuthUrl();
+        console.log('test urlForCurrentDomain', urlForCurrentDomain(getOAuthUrl()));
     }
     return urlForCurrentDomain(getOAuthUrl());
 };

--- a/src/components/shared/utils/login/login.ts
+++ b/src/components/shared/utils/login/login.ts
@@ -35,8 +35,21 @@ export const loginUrl = ({ language }: TLoginUrl) => {
     }`;
     const getOAuthUrl = () => {
         const current_domain = getCurrentProductionDomain();
-        const oauth_domain = current_domain || deriv_urls.DERIV_HOST_NAME;
-        return `https://oauth.${oauth_domain}/oauth2/authorize?app_id=${getAppId()}&l=${language}${marketing_queries}&brand=${website_name.toLowerCase()}`;
+        let oauth_domain = deriv_urls.DERIV_HOST_NAME;
+        console.log('test current domain: outside', current_domain);
+
+        if (current_domain) {
+            console.log('test current domain: inside', current_domain);
+            // Extract domain suffix (e.g., 'deriv.me' from 'dbot.deriv.me')
+            const domain_suffix = current_domain.replace(/^[^.]+\./, '');
+            oauth_domain = domain_suffix;
+        }
+
+        const url = `https://oauth.${oauth_domain}/oauth2/authorize?app_id=${getAppId()}&l=${language}${marketing_queries}&brand=${website_name.toLowerCase()}`;
+
+        console.log('test oauth domain final url:', url);
+
+        return url;
     };
 
     if (server_url && /qa/.test(server_url)) {


### PR DESCRIPTION
This pull request introduces updates to the `loginUrl` function in `src/components/shared/utils/login/login.ts`, primarily to enhance domain handling logic and add debugging logs. The changes aim to ensure the correct OAuth domain is constructed dynamically based on the current production domain.

### Enhancements to domain handling logic:
* Updated the logic to extract the domain suffix (e.g., `'deriv.me'` from `'dbot.deriv.me'`) when a current production domain is detected, and dynamically set the OAuth domain accordingly.

### Debugging additions:
* Added multiple `console.log` statements to log the current domain, OAuth domain, and constructed URLs at various stages for debugging purposes.