### PR TITLE
fix: added canary server url

### DIFF
--- a/src/components/shared/utils/config/config.ts
+++ b/src/components/shared/utils/config/config.ts
@@ -152,7 +152,7 @@ export const generateOAuthURL = () => {
     const configured_server_url = (LocalStorageUtils.getValue(LocalStorageConstants.configServerURL) ||
         localStorage.getItem('config.server_url')) as string;
 
-    const valid_server_urls = ['green.derivws.com', 'red.derivws.com', 'blue.derivws.com'];
+    const valid_server_urls = ['green.derivws.com', 'red.derivws.com', 'blue.derivws.com', 'canary.derivws.com'];
 
     if (
         configured_server_url &&

--- a/src/hooks/useTMB.ts
+++ b/src/hooks/useTMB.ts
@@ -71,7 +71,12 @@ const useTMB = (): UseTMBReturn => {
         try {
             const configServerUrl = localStorage.getItem('config.server_url');
             if (configServerUrl) {
-                const valid_server_urls = ['green.derivws.com', 'red.derivws.com', 'blue.derivws.com'];
+                const valid_server_urls = [
+                    'green.derivws.com',
+                    'red.derivws.com',
+                    'blue.derivws.com',
+                    'canary.derivws.com',
+                ];
 
                 let sessionsUrl: string;
                 // Special case: if config.server_url is one of the production WebSocket servers


### PR DESCRIPTION
This pull request adds support for a new server URL, `canary.derivws.com`, in two locations within the codebase. The change ensures that the new server URL is considered valid when determining server configurations.

### Updates to valid server URLs:

* [`src/components/shared/utils/config/config.ts`](diffhunk://#diff-49f2fb91bde2f51d34f95f726562ff893ed6f51557b764366c63997105a3043cL155-R155): Added `canary.derivws.com` to the `valid_server_urls` array in the `generateOAuthURL` function.
* [`src/hooks/useTMB.ts`](diffhunk://#diff-1693c842cbdff131e5a6d04a38e26e478527cfc01996cdc0d2ff41c37f551958L74-R79): Added `canary.derivws.com` to the `valid_server_urls` array in the `useTMB` hook.