### PR TITLE
fix: remove pwa from firefox and safari browsers

### DIFF
--- a/src/components/shared/utils/browser/browser_detect.ts
+++ b/src/components/shared/utils/browser/browser_detect.ts
@@ -31,3 +31,7 @@ const getUserBrowser = () => {
 };
 
 export const isSafariBrowser = () => getUserBrowser() === 'Safari';
+
+export const isFirefox = () => {
+    return navigator.userAgent.indexOf('Firefox') !== -1;
+};

--- a/src/pages/dashboard/announcements/announcements.tsx
+++ b/src/pages/dashboard/announcements/announcements.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { observer } from 'mobx-react-lite';
 import { useNavigate } from 'react-router-dom';
+import { isFirefox,isSafari } from '@/components/shared/utils/browser/browser_detect';
 import Text from '@/components/shared_ui/text';
 import { useStore } from '@/hooks/useStore';
 import { StandaloneBullhornRegularIcon } from '@deriv/quill-icons';
@@ -82,6 +83,11 @@ const Announcements = observer(({ is_mobile, is_tablet, handleTabChange }: TAnno
         }
 
         BOT_ANNOUNCEMENTS_LIST.map(item => {
+            // Skip PWA announcement entirely if Safari Desktop or Firefox
+            if (item.id === 'PWA_INSTALL_ANNOUNCE' && ((isSafari() && window.innerWidth > 768) || isFirefox())) {
+                return;
+            }
+
             let is_not_read = true;
             if (data && Object.prototype.hasOwnProperty.call(data, item.id)) {
                 is_not_read = data[item.id];

--- a/src/utils/pwa-utils.ts
+++ b/src/utils/pwa-utils.ts
@@ -1,3 +1,5 @@
+import { isFirefox,isSafari } from '@/components/shared/utils/browser/browser_detect';
+
 // PWA Utilities for Deriv Bot
 export interface BeforeInstallPromptEvent extends Event {
     readonly platforms: string[];
@@ -206,6 +208,14 @@ class PWAManager {
     }
 
     /**
+     * Check if browser is Safari Desktop (Safari with desktop screen width)
+     */
+    isSafariDesktop(): boolean {
+        // Check if Safari and desktop width (typically > 768px for desktop)
+        return isSafari() && window.innerWidth > 768;
+    }
+
+    /**
      * Get install instructions for current platform
      */
     getInstallInstructions(): string {
@@ -253,6 +263,8 @@ export const onPWAInstallStateChange = (callback: (canInstall: boolean) => void)
     pwaManager.onInstallStateChange(callback);
 export const onPWAUpdateAvailable = (callback: () => void) => pwaManager.onUpdateAvailable(callback);
 export const updatePWA = () => pwaManager.updateApp();
+export const isSafariDesktopBrowser = () => isSafari() && window.innerWidth > 768;
+export const isUnsupportedPWABrowser = () => (isSafari() && window.innerWidth > 768) || isFirefox();
 
 // Mobile source detection utilities
 export const isMobileSource = (): boolean => {
@@ -322,6 +334,16 @@ export const shouldShowPWAModal = (): boolean => {
 
     // Don't show on mobile (only desktop)
     if (pwaManager.isMobile()) {
+        return false;
+    }
+
+    // Don't show on Safari Desktop (Safari doesn't support PWA installation)
+    if (isSafari() && window.innerWidth > 768) {
+        return false;
+    }
+
+    // Don't show on Firefox (Firefox has limited PWA support)
+    if (isFirefox()) {
         return false;
     }
 


### PR DESCRIPTION
This pull request introduces improved browser detection utilities and updates the logic for displaying PWA-related announcements and modals, especially to better handle unsupported browsers like Safari Desktop and Firefox. The main goal is to prevent users on these browsers from seeing PWA installation prompts or announcements, as their support for PWA is limited or non-existent.

**Browser detection utilities:**

* Added `isFirefox` and improved usage of `isSafari` in `browser_detect.ts` to help identify unsupported browsers for PWA features.
* Updated imports and usage of these utilities in relevant files, such as `announcements.tsx` and `pwa-utils.ts`. [[1]](diffhunk://#diff-2fcabe876577ab0939c5a73c6e5f95eb78e51721fa37d75a78abe50c6775f416R5) [[2]](diffhunk://#diff-3479857ee8b4d0792566c21ae391074f5291c9b9658aa76c9a3a37fee8b510fdR1-R2)

**PWA support logic:**

* Updated the `Announcements` component to skip the PWA installation announcement for users on Safari Desktop or Firefox.
* Added new helper methods in `pwa-utils.ts` (`isSafariDesktop`, `isSafariDesktopBrowser`, and `isUnsupportedPWABrowser`) to centralize logic for unsupported browsers. [[1]](diffhunk://#diff-3479857ee8b4d0792566c21ae391074f5291c9b9658aa76c9a3a37fee8b510fdR210-R217) [[2]](diffhunk://#diff-3479857ee8b4d0792566c21ae391074f5291c9b9658aa76c9a3a37fee8b510fdR266-R267)
* Modified `shouldShowPWAModal` to prevent showing the PWA modal on Safari Desktop and Firefox, aligning the UI with actual platform support.