### PR TITLE
fix: pwa announcement date

### DIFF
--- a/src/pages/dashboard/announcements/config.tsx
+++ b/src/pages/dashboard/announcements/config.tsx
@@ -273,7 +273,7 @@ export const BOT_ANNOUNCEMENTS_LIST: TAnnouncementItem[] = [
         icon: IconAnnounce,
         title: localize('Install Deriv Bot as an App'),
         message: localize('Get faster access and better performance by installing Deriv Bot on your device.'),
-        date: '29 January 2025 00:00 UTC',
+        date: '28 August 2025 00:00 UTC',
         buttonAction: BUTTON_ACTION_TYPE.NO_ACTION,
         actionText: '',
     },


### PR DESCRIPTION
This pull request makes a minor update to the `BOT_ANNOUNCEMENTS_LIST` in `config.tsx`, changing the date of an announcement.

* Changed the `date` field for the "Install Deriv Bot as an App" announcement from '29 January 2025' to '28 August 2025'.