### PR TITLE
fix: chrome safari and firefox

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,17 +20,19 @@ if (mobileSourceInfo.isPWALaunch) {
     });
 }
 
-// Register PWA service worker (automatically skips Firefox)
+// Register PWA service worker (Chrome only - skips Safari and Firefox)
 registerPWA()
     .then(registration => {
         if (registration) {
             trackPWAEvent('service_worker_registered', {
                 scope: registration.scope,
                 source: mobileSourceInfo.isMobileSource ? 'mobile' : 'web',
+                browser: 'chrome',
             });
         } else {
-            trackPWAEvent('service_worker_not_supported_or_firefox', {
+            trackPWAEvent('service_worker_disabled_non_chrome', {
                 source: mobileSourceInfo.isMobileSource ? 'mobile' : 'web',
+                userAgent: navigator.userAgent,
             });
         }
     })

--- a/src/pages/dashboard/announcements/announcements.tsx
+++ b/src/pages/dashboard/announcements/announcements.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { observer } from 'mobx-react-lite';
 import { useNavigate } from 'react-router-dom';
-import { isFirefox,isSafari } from '@/components/shared/utils/browser/browser_detect';
+import { isFirefox, isSafari } from '@/components/shared/utils/browser/browser_detect';
 import Text from '@/components/shared_ui/text';
 import { useStore } from '@/hooks/useStore';
 import { StandaloneBullhornRegularIcon } from '@deriv/quill-icons';
@@ -83,9 +83,12 @@ const Announcements = observer(({ is_mobile, is_tablet, handleTabChange }: TAnno
         }
 
         BOT_ANNOUNCEMENTS_LIST.map(item => {
-            // Skip PWA announcement entirely if Safari Desktop or Firefox
-            if (item.id === 'PWA_INSTALL_ANNOUNCE' && ((isSafari() && window.innerWidth > 768) || isFirefox())) {
-                return;
+            // Skip PWA announcement entirely if not Chrome browser
+            if (item.id === 'PWA_INSTALL_ANNOUNCE') {
+                const isChrome = /Chrome/.test(navigator.userAgent) && !isFirefox() && !isSafari();
+                if (!isChrome) {
+                    return;
+                }
             }
 
             let is_not_read = true;

--- a/src/utils/pwa-utils.ts
+++ b/src/utils/pwa-utils.ts
@@ -51,15 +51,18 @@ class PWAManager {
             return null;
         }
 
-        // Don't register service worker on Firefox or Safari due to chunk loading issues
-        if (isFirefox() || isSafari()) {
-            const browser = isFirefox() ? 'Firefox' : 'Safari';
-            console.log(`[PWA] Service worker disabled on ${browser} to prevent chunk loading and login issues`);
+        // Only enable PWA service workers on Chrome browsers
+        const isChrome = /Chrome/.test(navigator.userAgent) && !isFirefox() && !isSafari();
+        if (!isChrome) {
+            const browser = isFirefox() ? 'Firefox' : isSafari() ? 'Safari' : 'Unknown';
+            console.log(
+                `[PWA] Service worker disabled on ${browser} - PWA only supported on Chrome to prevent chunk loading and login issues`
+            );
             return null;
         }
 
-        // Register service worker for Chrome and other compatible browsers
-        console.log('[PWA] Registering service worker for offline capabilities');
+        // Register service worker for Chrome only
+        console.log('[PWA] Registering service worker for Chrome browser offline capabilities');
 
         try {
             const registration = await navigator.serviceWorker.register('/sw.js', {
@@ -272,7 +275,8 @@ export const onPWAInstallStateChange = (callback: (canInstall: boolean) => void)
 export const onPWAUpdateAvailable = (callback: () => void) => pwaManager.onUpdateAvailable(callback);
 export const updatePWA = () => pwaManager.updateApp();
 export const isSafariDesktopBrowser = () => isSafari() && window.innerWidth > 768;
-export const isUnsupportedPWABrowser = () => (isSafari() && window.innerWidth > 768) || isFirefox();
+export const isUnsupportedPWABrowser = () => !(/Chrome/.test(navigator.userAgent) && !isFirefox() && !isSafari());
+export const isChromeOnlyPWA = () => /Chrome/.test(navigator.userAgent) && !isFirefox() && !isSafari();
 
 // Mobile source detection utilities
 export const isMobileSource = (): boolean => {
@@ -340,18 +344,14 @@ export const shouldShowPWAModal = (): boolean => {
         return false;
     }
 
+    // Only show PWA modal on Chrome browsers
+    const isChrome = /Chrome/.test(navigator.userAgent) && !isFirefox() && !isSafari();
+    if (!isChrome) {
+        return false;
+    }
+
     // Don't show on mobile (only desktop)
     if (pwaManager.isMobile()) {
-        return false;
-    }
-
-    // Don't show on Safari Desktop (Safari doesn't support PWA installation)
-    if (isSafari() && window.innerWidth > 768) {
-        return false;
-    }
-
-    // Don't show on Firefox (Firefox has limited PWA support)
-    if (isFirefox()) {
         return false;
     }
 


### PR DESCRIPTION
This pull request restricts PWA (Progressive Web App) support exclusively to Chrome browsers, updating both the logic and user-facing elements to reflect this change. The code now checks for Chrome specifically, disables PWA features on all other browsers (including Safari and Firefox), and updates related user interface logic and event tracking accordingly.

**PWA Support Restriction to Chrome:**

- Updated the service worker registration logic in `pwa-utils.ts` to only enable registration on Chrome browsers, with improved logging and early returns for unsupported browsers.
- Modified the function `isUnsupportedPWABrowser` to return `true` for any non-Chrome browser, and added a new utility `isChromeOnlyPWA` for Chrome detection.
- Adjusted the logic in `shouldShowPWAModal` to only show the PWA modal on Chrome, removing previous checks for Safari and Firefox specifically.

**User Interface and Event Tracking Updates:**

- Changed the announcements logic in `announcements.tsx` so the PWA install announcement is only shown for Chrome users, using the updated browser detection.
- Updated event tracking and service worker registration in `main.tsx` to reflect Chrome-only support, including more descriptive event names and additional tracking details.