### PR TITLE
fix: rudderstack event for pwa

### DIFF
--- a/src/analytics/rudderstack-common-events.ts
+++ b/src/analytics/rudderstack-common-events.ts
@@ -111,6 +111,7 @@ export const rudderStackSendPWAInstallEvent = () => {
     Analytics.trackEvent('ce_bot_form', {
         action: ACTION.PWA_INSTALL,
         form_name,
-        subpage_name: 'dashboard',
+        subform_name: 'announcements',
+        subform_source: 'dashboard',
     });
 };


### PR DESCRIPTION
This pull request makes a minor update to the analytics event tracking for PWA installs. The change updates the event properties to use `subform_name` and `subform_source` instead of the previous `subpage_name`, and sets their values accordingly.

- Updated the `rudderStackSendPWAInstallEvent` function in `src/analytics/rudderstack-common-events.ts` to replace the `subpage_name` property with `subform_name` and `subform_source` when tracking the PWA install event.