### PR TITLE
fix: announcement name for pwa trigger

### DIFF
--- a/src/pages/dashboard/announcements/utils/accumulator-helper-functions.ts
+++ b/src/pages/dashboard/announcements/utils/accumulator-helper-functions.ts
@@ -1,4 +1,6 @@
 import { load, save_types } from '@/external/bot-skeleton';
+import { rudderStackSendPWAInstallEvent } from '../../../analytics/rudderstack-common-events';
+import { rudderStackSendAnnouncementClickEvent } from '../../../analytics/rudderstack-dashboard';
 import { ANNOUNCEMENTS, BUTTON_ACTION_TYPE, TAnnouncement, TAnnouncementItem } from '../config';
 
 export const handleOnConfirmAccumulator = () => {
@@ -53,6 +55,14 @@ export const performButtonAction = (
             // Special handling for PWA announcement - show PWA modal directly and close announcement panel
             if (item.id === 'PWA_INSTALL_ANNOUNCE') {
                 return () => {
+                    // Send announcement click tracking event
+                    rudderStackSendAnnouncementClickEvent({
+                        announcement_name: ANNOUNCEMENTS[item.id].announcement.main_title,
+                    });
+
+                    // Send PWA install event
+                    rudderStackSendPWAInstallEvent();
+
                     // Mark as read
                     let data: Record<string, boolean> | null = null;
                     data = JSON.parse(localStorage.getItem('bot-announcements') ?? '{}');


### PR DESCRIPTION
This pull request enhances analytics tracking for PWA-related announcements in the dashboard by integrating RudderStack event tracking into the announcement utilities. The most important changes are:

**Analytics Integration:**

* Imported `rudderStackSendPWAInstallEvent` and `rudderStackSendAnnouncementClickEvent` from the appropriate analytics modules into `accumulator-helper-functions.ts` to enable event tracking for announcement interactions.

**Event Tracking on PWA Announcement:**

* Updated the `performButtonAction` function to send an announcement click event and a PWA install event to RudderStack when the PWA install announcement is triggered, improving observability of user interactions with PWA-related announcements.