### PR TITLE
fix: pwa install

### DIFF
--- a/src/pages/dashboard/announcements/config.tsx
+++ b/src/pages/dashboard/announcements/config.tsx
@@ -275,7 +275,7 @@ export const BOT_ANNOUNCEMENTS_LIST: TAnnouncementItem[] = [
         title: localize('Install Deriv Bot as an App'),
         message: localize('Get faster access and better performance by installing Deriv Bot on your device.'),
         date: '29 August 2025 00:00 UTC',
-        buttonAction: BUTTON_ACTION_TYPE.NO_ACTION,
+        buttonAction: BUTTON_ACTION_TYPE.MODAL_BUTTON_ACTION,
         actionText: '',
     },
     {

--- a/src/pages/dashboard/announcements/utils/accumulator-helper-functions.ts
+++ b/src/pages/dashboard/announcements/utils/accumulator-helper-functions.ts
@@ -1,6 +1,4 @@
 import { load, save_types } from '@/external/bot-skeleton';
-import { rudderStackSendPWAInstallEvent } from '../../../analytics/rudderstack-common-events';
-import { rudderStackSendAnnouncementClickEvent } from '../../../analytics/rudderstack-dashboard';
 import { ANNOUNCEMENTS, BUTTON_ACTION_TYPE, TAnnouncement, TAnnouncementItem } from '../config';
 
 export const handleOnConfirmAccumulator = () => {
@@ -52,29 +50,6 @@ export const performButtonAction = (
             return false;
         }
         case BUTTON_ACTION_TYPE.NO_ACTION: {
-            // Special handling for PWA announcement - show PWA modal directly and close announcement panel
-            if (item.id === 'PWA_INSTALL_ANNOUNCE') {
-                return () => {
-                    // Send announcement click tracking event
-                    rudderStackSendAnnouncementClickEvent({
-                        announcement_name: ANNOUNCEMENTS[item.id].announcement.main_title,
-                    });
-
-                    // Send PWA install event
-                    rudderStackSendPWAInstallEvent();
-
-                    // Mark as read
-                    let data: Record<string, boolean> | null = null;
-                    data = JSON.parse(localStorage.getItem('bot-announcements') ?? '{}');
-                    localStorage?.setItem('bot-announcements', JSON.stringify({ ...data, [item.id]: false }));
-
-                    // Trigger PWA modal
-                    window.dispatchEvent(new CustomEvent('showPWAInstallModal'));
-
-                    // Close announcements panel by triggering a custom event
-                    window.dispatchEvent(new CustomEvent('closeAnnouncementsPanel'));
-                };
-            }
             return false;
         }
         default:


### PR DESCRIPTION
This pull request updates the handling of the "Install Deriv Bot as an App" announcement and cleans up related code. The most significant change is switching the button action type for this announcement, which simplifies how its interaction is managed. Additionally, some analytics tracking code and special-case logic have been removed for clarity and maintainability.

**Announcement button action update:**

* Changed the `buttonAction` for the "Install Deriv Bot as an App" announcement from `NO_ACTION` to `MODAL_BUTTON_ACTION` in `BOT_ANNOUNCEMENTS_LIST`, aligning its behavior with other modal-triggering announcements.

**Code cleanup and logic simplification:**

* Removed special-case logic for handling the PWA install announcement under the `NO_ACTION` button type in `performButtonAction`, as it's now handled via the modal action type.
* Removed unused analytics import statements (`rudderStackSendPWAInstallEvent` and `rudderStackSendAnnouncementClickEvent`) from `accumulator-helper-functions.ts`.