### PR TITLE
fix: announcement dialog

### DIFF
--- a/src/pages/dashboard/announcements/announcement-dialog.scss
+++ b/src/pages/dashboard/announcements/announcement-dialog.scss
@@ -1,6 +1,21 @@
 @use 'components/shared/styles/mixins' as *;
 
 .announcement-dialog {
+    .announcement-dialog--pwa__body-main-content {
+        padding: 20px;
+
+        .announcement-dialog--pwa__body-item {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            margin-top: 1rem;
+
+            p {
+                margin-left: 1rem;
+            }
+        }
+    }
+
     .dc-dialog {
         &__dialog {
             max-width: calc(440px - 4.8rem);
@@ -96,7 +111,8 @@
     &__body-icon {
         &--accumulator_announce,
         &--moving_strategies_announce,
-        &--blockly_announce {
+        &--blockly_announce,
+        &--pwa_install_announce {
             display: flex;
             justify-content: center;
             align-items: center;
@@ -111,6 +127,22 @@
         &--accumulator_announce {
             border-radius: 0.8rem;
             background-color: var(--general-section-1);
+        }
+
+        &--pwa_install_announce {
+            border-radius: 0.8rem;
+            background-color: var(--general-section-1);
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            margin-bottom: 1.5rem;
+            padding: 2rem;
+
+            // Add PWA icon styling if needed
+            svg {
+                width: 6rem;
+                height: 6rem;
+            }
         }
     }
 
@@ -160,6 +192,26 @@
 
         &--accumulator_announce {
             text-align: center;
+        }
+
+        &--pwa_install_announce {
+            text-align: center;
+            font-weight: 600;
+            color: var(--text-prominent);
+        }
+    }
+
+    // PWA announcement specific styling
+    &--pwa {
+        .dc-dialog__footer {
+            .dc-btn--primary {
+                background-color: var(--status-danger) !important;
+                border-color: var(--status-danger) !important;
+
+                .dc-btn__text {
+                    color: var(--text-colored-background) !important;
+                }
+            }
         }
     }
 }

--- a/src/pages/dashboard/announcements/config.tsx
+++ b/src/pages/dashboard/announcements/config.tsx
@@ -5,6 +5,7 @@ import Text from '@/components/shared_ui/text';
 import { DBOT_TABS } from '@/constants/bot-contents';
 import { Localize, localize } from '@deriv-com/translations';
 import { rudderStackSendOpenEvent, rudderStackSendPWAInstallEvent } from '../../../analytics/rudderstack-common-events';
+import { showInstallPrompt } from '../../../utils/pwa-utils';
 import { handleOnConfirmAccumulator } from './utils/accumulator-helper-functions';
 import { IconAnnounce } from './announcement-components';
 
@@ -213,7 +214,8 @@ export const ANNOUNCEMENTS: Record<string, TAnnouncement> = {
             id: 'PWA_INSTALL_ANNOUNCE',
             main_title: localize('Install Deriv Bot as an App'),
             confirm_button_text: localize('Install Now'),
-            base_classname: 'announcement-dialog',
+            cancel_button_text: localize('Maybe later'),
+            base_classname: 'announcement-dialog announcement-dialog--pwa',
             title: (
                 <Localize i18n_default_text='<0>Get the full app experience</0>' components={[<strong key={0} />]} />
             ),
@@ -237,8 +239,8 @@ export const ANNOUNCEMENTS: Record<string, TAnnouncement> = {
         should_not_be_cancel: false,
         onConfirm: () => {
             rudderStackSendPWAInstallEvent();
-            // Trigger PWA install modal directly
-            window.dispatchEvent(new CustomEvent('showPWAInstallModal'));
+            // Trigger actual PWA install prompt
+            showInstallPrompt();
         },
     },
 };


### PR DESCRIPTION
This pull request introduces new styles and configuration updates to support a Progressive Web App (PWA) installation announcement in the dashboard. The changes enhance the appearance and behavior of the PWA install dialog, add a cancel button, and ensure the actual PWA install prompt is triggered when the user clicks "Install Now."

**PWA Installation Announcement Enhancements:**

* Added new CSS classes for the PWA announcement dialog, including layout, icon, and button styles in `announcement-dialog.scss`. This ensures the PWA install dialog has a distinct look and feel, with centered content and a prominent install button. [[1]](diffhunk://#diff-b13ef5d9c4deedfcb658d8757695e07a0390e18da12bc78cc325c673c19479f0R4-R18) [[2]](diffhunk://#diff-b13ef5d9c4deedfcb658d8757695e07a0390e18da12bc78cc325c673c19479f0L99-R115) [[3]](diffhunk://#diff-b13ef5d9c4deedfcb658d8757695e07a0390e18da12bc78cc325c673c19479f0R131-R146) [[4]](diffhunk://#diff-b13ef5d9c4deedfcb658d8757695e07a0390e18da12bc78cc325c673c19479f0R196-R215)
* Updated the PWA announcement configuration in `config.tsx` to include a cancel button ("Maybe later"), apply the new base class for styling, and trigger the actual PWA install prompt using `showInstallPrompt()` instead of a custom event. [[1]](diffhunk://#diff-b664fb87e4554156313927186a9ad7a5e51ec76dc3ca87a909d7fcd1cdbc0cd9L216-R218) [[2]](diffhunk://#diff-b664fb87e4554156313927186a9ad7a5e51ec76dc3ca87a909d7fcd1cdbc0cd9L240-R243)
* Imported the `showInstallPrompt` utility function to facilitate the PWA installation prompt.